### PR TITLE
all-repos: update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           pip install wheel setuptools
           python setup.py sdist bdist_wheel
       - name: Upload Python Packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ github.sha }}
           path: |


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos