### PR TITLE
Start putting together python packaging with craft

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,4 +1,16 @@
-minVersion: 0.34.1
-# TODO -- craft setup
+minVersion: 1.20.0
+github:
+  owner: getsentry
+  repo: sentry-protos
+targets:
+  - name: pypi
+  - name: github
+  - name: sentry-pypi
+    internalPypiRepo: getsentry/pypi
+artifactProvider:
+  name: github
+requireNames:
+  - /^sentry_protos.+-py3-none-any.whl$/
+  - /^sentry_protos.+.tar.gz$/
 changelog: CHANGELOG.md
 changelogPolicy: auto

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,28 @@
+name: build
+
+on:
+  push:
+    branches:
+      - release/**
+
+jobs:
+  dist:
+    name: python distribution packages
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.11
+
+      - run: |
+          pip install .
+          pip install wheel
+          python setup.py bdist_wheel
+      - uses: actions/upload-artifact@v3.1.1
+        with:
+          name: ${{ github.sha }}
+          path: dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,29 +1,29 @@
+name: release
+
 on:
-  push:
-    branches:
-      - 'release/**'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to release
+        required: true
+      force:
+        description: Force a release even when there are release-blockers (optional)
+        required: false
 
 jobs:
-  build_release:
-    name: Build johen Package
+  release:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [ "3.10", "3.11" ]
-    timeout-minutes: 10
-
+    name: 'Release a new version'
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v2
         with:
-          python-version: ${{ matrix.python-version }}
-      - name: Build Packages
-        run: |
-          pip install wheel setuptools
-          python setup.py sdist bdist_wheel
-      - name: Upload Python Packages
-        uses: actions/upload-artifact@v3
+          token: ${{ secrets.GH_RELEASE_PAT }}
+          fetch-depth: 0
+
+      - name: Prepare release
+        uses: getsentry/action-prepare-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
         with:
-          name: ${{ github.sha }}
-          path: |
-            dist/*
+          version: ${{ github.event.inputs.version }}
+          force: ${{ github.event.inputs.force }}


### PR DESCRIPTION
With this I was able to get release branches pushed from my local machine to GitHub.The `release.yml` workflow can be used to manually create releases as required. Part of the prepare-release action is to prepare and push a release branch.  Once a release branch is pushed the `build.yml` workflow should create artifacts, that can be published.

I'm going to start with python wheels. I'll add rust crates once python wheels are working.