### PR TITLE
Fix rust packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,9 +165,9 @@ checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "cc"
-version = "1.1.13"
+version = "1.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72db2f7947ecee9b03b510377e8bb9077afa27176fdbff55c51027e976fdcc48"
+checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
 dependencies = [
  "shlex",
 ]
@@ -202,9 +202,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "fixedbitset"
@@ -282,9 +282,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
+checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -460,9 +460,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "libc"
-version = "0.2.156"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5f43f184355eefb8d17fc948dbecf6c13be3c141f20d834ae842193a448c72a"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "linux-raw-sys"
@@ -595,9 +595,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.20"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
+checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -667,9 +667,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -745,6 +745,7 @@ version = "0.1.10"
 dependencies = [
  "glob",
  "prost",
+ "prost-build",
  "prost-types",
  "regex",
  "tokio",
@@ -773,7 +774,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "prost",
  "prost-types",
@@ -783,18 +784,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.208"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2"
+checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.208"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
+checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -834,9 +835,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.74"
+version = "2.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fceb41e3d546d0bd83421d3409b1460cc7444cd389341a4c880fe7a042cb3d7"
+checksum = "578e081a14e0cefc3279b0472138c513f37b41a08d5a3cca9b6e4e8ceb6cd525"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -870,9 +871,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.39.2"
+version = "1.39.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
+checksum = "9babc99b9923bfa4804bd74722ff02c0381021eafa4db9949217e3be8e84fff5"
 dependencies = [
  "backtrace",
  "bytes",
@@ -921,9 +922,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38659f4a91aba8598d27821589f5db7dddd94601e7a01b1e485a50e5484c7401"
+checksum = "c6f6ba989e4b2c58ae83d862d3a3e27690b6e3ae630d0deb59f3697f32aa88ad"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -951,9 +952,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568392c5a2bd0020723e3f387891176aabafe36fd9fcd074ad309dfa0c8eb964"
+checksum = "fe4ee8877250136bd7e3d2331632810a4df4ea5e004656990d8d66d2f5ee8a67"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,7 +745,6 @@ version = "0.1.10"
 dependencies = [
  "glob",
  "prost",
- "prost-build",
  "prost-types",
  "regex",
  "tokio",

--- a/rustgenerator/Cargo.toml
+++ b/rustgenerator/Cargo.toml
@@ -9,7 +9,6 @@ glob = "0.3.1"
 tonic = "0.12"
 tonic-build = "0.12"
 prost = "0.13"
-prost-build = "0.13"
 prost-types = "0.13"
 regex = "1.10.5"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/rustgenerator/Cargo.toml
+++ b/rustgenerator/Cargo.toml
@@ -9,6 +9,7 @@ glob = "0.3.1"
 tonic = "0.12"
 tonic-build = "0.12"
 prost = "0.13"
+prost-build = "0.13"
 prost-types = "0.13"
 regex = "1.10.5"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/rustgenerator/src/main.rs
+++ b/rustgenerator/src/main.rs
@@ -32,12 +32,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let proto_dir = "./proto/sentry_protos";
     println!("Generating protos in {}", proto_dir);
 
-    let proto_files = find_proto_files(proto_dir);
-
     // collect module names to generate lib.rs
     let mut module_metadata = Vec::new();
     let mut proto_file_str: Vec<PathBuf> = Vec::new();
-    for file in proto_files {
+    for file in find_proto_files(proto_dir) {
         module_metadata.push(get_module_info(&file));
         proto_file_str.push(file);
     }

--- a/rustgenerator/src/main.rs
+++ b/rustgenerator/src/main.rs
@@ -30,6 +30,8 @@ fn find_proto_files(proto_dir: &str) -> impl Iterator<Item = PathBuf> {
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let proto_dir = "./proto/sentry_protos";
+    println!("Generating protos in {}", proto_dir);
+
     let proto_files = find_proto_files(proto_dir);
 
     // collect module names to generate lib.rs
@@ -41,6 +43,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Compile rust code for all proto files.
+    println!("Generating proto bindings");
     prost_build::Config::new()
         .out_dir("./rust/src")
         .compile_protos(&proto_file_str, &["./proto"])
@@ -64,6 +67,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Generate lib.rs with the proto modules.
+    println!("Generating src/lib.rs");
     let mut lib_file = File::create("./rust/src/lib.rs").unwrap();
     lib_file.write_all(lib_rs.as_bytes()).expect("Failed to write lib.rs");
 

--- a/rustgenerator/src/main.rs
+++ b/rustgenerator/src/main.rs
@@ -44,9 +44,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Compile rust code for all proto files.
     println!("Generating proto bindings");
-    prost_build::Config::new()
+    tonic_build::configure()
         .out_dir("./rust/src")
-        .compile_protos(&proto_file_str, &["./proto"])
+        .emit_rerun_if_changed(false)
+        .compile(&proto_file_str, &["./proto"])
         .unwrap();
 
     let mut visited: Vec<&str> = vec![];


### PR DESCRIPTION
- Fix the issue with generated `options` module that doesn't include all of the structs.
- Fix non `v1` module names being generated incorrectly.