### PR TITLE
feat(eap): Add a "hack" message that can isolate gross stuff needed by the product

### DIFF
--- a/proto/sentry_protos/snuba/v1alpha/endpoint_aggregate_bucket.proto
+++ b/proto/sentry_protos/snuba/v1alpha/endpoint_aggregate_bucket.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package sentry_protos.snuba.v1alpha;
 
+import "sentry_protos/snuba/v1alpha/endpoint_hacks.proto";
 import "sentry_protos/snuba/v1alpha/request_common.proto";
 import "sentry_protos/snuba/v1alpha/trace_item_attribute.proto";
 import "sentry_protos/snuba/v1alpha/trace_item_filter.proto";
@@ -23,7 +24,7 @@ message AggregateBucketRequest {
   TraceItemFilter filter = 5;
   uint64 granularity_secs = 6;
   AttributeKey key = 7;
-  optional AttributeKeyTransformContext attribute_key_transform_context = 8;
+  optional EndpointHacks hacks = 8;
 
   //TODO: group by, topn, etc, not necessary for MVP
 }

--- a/proto/sentry_protos/snuba/v1alpha/endpoint_hacks.proto
+++ b/proto/sentry_protos/snuba/v1alpha/endpoint_hacks.proto
@@ -1,0 +1,26 @@
+syntax = "proto3";
+
+package sentry_protos.snuba.v1alpha;
+
+// Things we need to support for legacy reasons, that should be avoided if possible
+// If you use this, expect bugs and/or performance issues.
+// Use it as a scratchpad for features that are product requirements, but not thought through enough
+// to be fully fledged members of a platform
+message EndpointHacks {
+  //Map a source column (like project id) to a discrete set of values (like project names)
+  message UIntToStringColumnMapping {
+    string source_column = 1;
+    string dest_column = 2;
+    map<uint64, string> mapping = 3;
+  }
+
+  // Map a source column (like 'release') to discrete values (like 'latest' -> '1.1.1')
+  message StringToStringColumnMapping {
+    string source_column = 1;
+    string dest_column = 2;
+    map<string, string> mapping = 3;
+  }
+
+  repeated UIntToStringColumnMapping uint_to_string_column_mappings = 1;
+  repeated StringToStringColumnMapping string_to_string_column_mappings = 2;
+}

--- a/proto/sentry_protos/snuba/v1alpha/endpoint_span_samples.proto
+++ b/proto/sentry_protos/snuba/v1alpha/endpoint_span_samples.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package sentry_protos.snuba.v1alpha;
 
+import "sentry_protos/snuba/v1alpha/endpoint_hacks.proto";
 import "sentry_protos/snuba/v1alpha/request_common.proto";
 import "sentry_protos/snuba/v1alpha/trace_item_attribute.proto";
 import "sentry_protos/snuba/v1alpha/trace_item_filter.proto";
@@ -18,7 +19,7 @@ message SpanSamplesRequest {
   repeated AttributeKey keys = 4;
   uint32 limit = 5;
   //contains context for special columns like project_name, only needs to be included if you are requesting one of those
-  optional AttributeKeyTransformContext attribute_key_transform_context = 6;
+  optional EndpointHacks hacks = 6;
 }
 
 message SpanSample {

--- a/proto/sentry_protos/snuba/v1alpha/trace_item_attribute.proto
+++ b/proto/sentry_protos/snuba/v1alpha/trace_item_attribute.proto
@@ -18,11 +18,6 @@ message AttributeKey {
   string name = 2;
 }
 
-// Special cases for attributes, in particular things like project name
-message AttributeKeyTransformContext {
-  map<uint64, string> project_ids_to_names = 1;
-}
-
 message AttributeValue {
   oneof value {
     bool val_bool = 1;


### PR DESCRIPTION
Some features like sorting on project_name can't be solved easily with our current implementation.

This adds a 'hack' message that can contain complex product logic that we need to support but don't have a good answer for yet.