### PR TITLE
feat(eap): add support for virtual columns in the protobuf

### DIFF
--- a/proto/sentry_protos/snuba/v1alpha/endpoint_aggregate_bucket.proto
+++ b/proto/sentry_protos/snuba/v1alpha/endpoint_aggregate_bucket.proto
@@ -23,7 +23,7 @@ message AggregateBucketRequest {
   TraceItemFilter filter = 5;
   uint64 granularity_secs = 6;
   AttributeKey key = 7;
-  optional AttributeKeyTransformContext attribute_key_transform_context = 8;
+  repeated VirtualColumnContext virtual_column_context = 8;
 
   //TODO: group by, topn, etc, not necessary for MVP
 }

--- a/proto/sentry_protos/snuba/v1alpha/endpoint_span_samples.proto
+++ b/proto/sentry_protos/snuba/v1alpha/endpoint_span_samples.proto
@@ -17,8 +17,7 @@ message SpanSamplesRequest {
   repeated OrderBy order_by = 3;
   repeated AttributeKey keys = 4;
   uint32 limit = 5;
-  //contains context for special columns like project_name, only needs to be included if you are requesting one of those
-  optional AttributeKeyTransformContext attribute_key_transform_context = 6;
+  repeated VirtualColumnContext virtual_column_context = 6;
 }
 
 message SpanSample {

--- a/proto/sentry_protos/snuba/v1alpha/trace_item_attribute.proto
+++ b/proto/sentry_protos/snuba/v1alpha/trace_item_attribute.proto
@@ -18,9 +18,14 @@ message AttributeKey {
   string name = 2;
 }
 
-// Special cases for attributes, in particular things like project name
-message AttributeKeyTransformContext {
-  map<uint64, string> project_ids_to_names = 1;
+// custom mappings of column values which are not present in EAP storage
+// for example, project name is changeable by the user and not stored in EAP
+// but sorting by the project name may be desired. This struct carries that mapping
+// data
+message VirtualColumnContext {
+  string from_column_name = 1;
+  string to_column_name = 2;
+  map<string, string> value_map = 3;
 }
 
 message AttributeValue {


### PR DESCRIPTION
There is a requirement to have the ability to search by virtual columns. Remove the AttributeKeyTransformContext which special cased proejct id and make it generic for any desired virtual column