### PR TITLE
fix(eap): pluralize virtual column contexts

### DIFF
--- a/proto/sentry_protos/snuba/v1alpha/endpoint_span_samples.proto
+++ b/proto/sentry_protos/snuba/v1alpha/endpoint_span_samples.proto
@@ -17,7 +17,7 @@ message SpanSamplesRequest {
   repeated OrderBy order_by = 3;
   repeated AttributeKey keys = 4;
   uint32 limit = 5;
-  repeated VirtualColumnContext virtual_column_context = 6;
+  repeated VirtualColumnContext virtual_column_contexts = 6;
 }
 
 message SpanSample {


### PR DESCRIPTION
forgot to pluralize a repeated field, this makes things confusing