### PR TITLE
feat(eap): separate value types in endpoint

### DIFF
--- a/proto/sentry_protos/snuba/v1alpha/endpoint_tags_list.proto
+++ b/proto/sentry_protos/snuba/v1alpha/endpoint_tags_list.proto
@@ -10,7 +10,8 @@ message TraceItemAttributesRequest {
   RequestMeta meta = 1;
   uint32 limit = 2;
   uint32 offset = 3;
-  AttributeKey.Type type = 4;
+  string trace_item_name = 4;
+  AttributeKey.Type type = 5;
 }
 
 message TraceItemAttributesResponse {
@@ -23,9 +24,10 @@ message TraceItemAttributesResponse {
 
 message AttributeValuesRequest {
   RequestMeta meta = 1;
-  string name = 2;
-  uint32 limit = 3;
-  uint32 offset = 4;
+  string trace_item_name = 2;
+  string name = 3;
+  uint32 limit = 4;
+  uint32 offset = 5;
 }
 
 message AttributeValuesResponse {

--- a/proto/sentry_protos/snuba/v1alpha/endpoint_tags_list.proto
+++ b/proto/sentry_protos/snuba/v1alpha/endpoint_tags_list.proto
@@ -10,7 +10,6 @@ message TraceItemAttributesRequest {
   RequestMeta meta = 1;
   uint32 limit = 2;
   uint32 offset = 3;
-  string trace_item_name = 4;
   AttributeKey.Type type = 5;
 }
 
@@ -24,7 +23,6 @@ message TraceItemAttributesResponse {
 
 message AttributeValuesRequest {
   RequestMeta meta = 1;
-  string trace_item_name = 2;
   string name = 3;
   uint32 limit = 4;
   uint32 offset = 5;

--- a/proto/sentry_protos/snuba/v1alpha/endpoint_tags_list.proto
+++ b/proto/sentry_protos/snuba/v1alpha/endpoint_tags_list.proto
@@ -24,8 +24,11 @@ message TraceItemAttributesResponse {
 message AttributeValuesRequest {
   RequestMeta meta = 1;
   string name = 3;
-  uint32 limit = 4;
-  uint32 offset = 5;
+  // a substring of the value being searched,
+  // only strict substring supported, no regex
+  string value_substring_match = 4;
+  uint32 limit = 5;
+  uint32 offset = 6;
 }
 
 message AttributeValuesResponse {

--- a/proto/sentry_protos/snuba/v1alpha/endpoint_tags_list.proto
+++ b/proto/sentry_protos/snuba/v1alpha/endpoint_tags_list.proto
@@ -3,24 +3,31 @@ syntax = "proto3";
 package sentry_protos.snuba.v1alpha;
 
 import "sentry_protos/snuba/v1alpha/request_common.proto";
+import "sentry_protos/snuba/v1alpha/trace_item_attribute.proto";
 
 //A request for "which tags are available for these projects between these dates" - used for things like autocompletion
-message TagsListRequest {
+message TraceItemAttributesRequest {
   RequestMeta meta = 1;
   uint32 limit = 2;
   uint32 offset = 3;
+  AttributeKey.Type type = 4;
 }
 
-message TagsListResponse {
-  enum Type {
-    TYPE_UNSPECIFIED = 0;
-    TYPE_STRING = 1;
-    TYPE_NUMBER = 2;
-  }
-
+message TraceItemAttributesResponse {
   message Tag {
     string name = 1;
-    Type type = 2;
+    AttributeKey.Type type = 2;
   }
   repeated Tag tags = 1;
+}
+
+message AttributeValuesRequest {
+  RequestMeta meta = 1;
+  string name = 2;
+  uint32 limit = 3;
+  uint32 offset = 4;
+}
+
+message AttributeValuesResponse {
+  repeated string values = 1;
 }

--- a/proto/sentry_protos/snuba/v1alpha/request_common.proto
+++ b/proto/sentry_protos/snuba/v1alpha/request_common.proto
@@ -12,4 +12,10 @@ message RequestMeta {
   repeated uint64 project_ids = 4;
   google.protobuf.Timestamp start_timestamp = 5;
   google.protobuf.Timestamp end_timestamp = 6;
+  TraceItemName trace_item_name = 7;
+}
+
+enum TraceItemName {
+  TRACE_ITEM_NAME_UNSPECIFIED = 0;
+  TRACE_ITEM_NAME_EAP_SPANS = 1;
 }


### PR DESCRIPTION
1. Add a type argument to the tags endpoint
2. Rename according to EAP terminology
3. Add `trace_item_name` to request payload (in the current case it's `eap_spans`)
4. Add endpoint for attrivute values given specific key