### PR TITLE
chore: Move EAP protocols out of unstable

### DIFF
--- a/proto/sentry_protos/snuba/v1/endpoint_aggregate_bucket.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_aggregate_bucket.proto
@@ -1,10 +1,10 @@
 syntax = "proto3";
 
-package sentry_protos.snuba.v1alpha;
+package sentry_protos.snuba.v1;
 
-import "sentry_protos/snuba/v1alpha/request_common.proto";
-import "sentry_protos/snuba/v1alpha/trace_item_attribute.proto";
-import "sentry_protos/snuba/v1alpha/trace_item_filter.proto";
+import "sentry_protos/snuba/v1/request_common.proto";
+import "sentry_protos/snuba/v1/trace_item_attribute.proto";
+import "sentry_protos/snuba/v1/trace_item_filter.proto";
 
 message AggregateBucketRequest {
   RequestMeta meta = 1;

--- a/proto/sentry_protos/snuba/v1/endpoint_span_samples.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_span_samples.proto
@@ -1,10 +1,10 @@
 syntax = "proto3";
 
-package sentry_protos.snuba.v1alpha;
+package sentry_protos.snuba.v1;
 
-import "sentry_protos/snuba/v1alpha/request_common.proto";
-import "sentry_protos/snuba/v1alpha/trace_item_attribute.proto";
-import "sentry_protos/snuba/v1alpha/trace_item_filter.proto";
+import "sentry_protos/snuba/v1/request_common.proto";
+import "sentry_protos/snuba/v1/trace_item_attribute.proto";
+import "sentry_protos/snuba/v1/trace_item_filter.proto";
 
 message SpanSamplesRequest {
   message OrderBy {

--- a/proto/sentry_protos/snuba/v1/endpoint_tags_list.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_tags_list.proto
@@ -1,9 +1,9 @@
 syntax = "proto3";
 
-package sentry_protos.snuba.v1alpha;
+package sentry_protos.snuba.v1;
 
-import "sentry_protos/snuba/v1alpha/request_common.proto";
-import "sentry_protos/snuba/v1alpha/trace_item_attribute.proto";
+import "sentry_protos/snuba/v1/request_common.proto";
+import "sentry_protos/snuba/v1/trace_item_attribute.proto";
 
 //A request for "which tags are available for these projects between these dates" - used for things like autocompletion
 message TraceItemAttributesRequest {

--- a/proto/sentry_protos/snuba/v1/request_common.proto
+++ b/proto/sentry_protos/snuba/v1/request_common.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sentry_protos.snuba.v1alpha;
+package sentry_protos.snuba.v1;
 
 import "google/protobuf/timestamp.proto";
 

--- a/proto/sentry_protos/snuba/v1/trace_item_attribute.proto
+++ b/proto/sentry_protos/snuba/v1/trace_item_attribute.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sentry_protos.snuba.v1alpha;
+package sentry_protos.snuba.v1;
 
 message AttributeKey {
   enum Type { //this mostly reflects what types are able to be ingested, see eap_spans consumer for ingest details

--- a/proto/sentry_protos/snuba/v1/trace_item_filter.proto
+++ b/proto/sentry_protos/snuba/v1/trace_item_filter.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
-package sentry_protos.snuba.v1alpha;
+package sentry_protos.snuba.v1;
 
-import "sentry_protos/snuba/v1alpha/trace_item_attribute.proto";
+import "sentry_protos/snuba/v1/trace_item_attribute.proto";
 
 message AndFilter {
   repeated TraceItemFilter filters = 1;


### PR DESCRIPTION
We're using these in code we're shipping to production. Unstable packages shouldn't be used in production systems as there are no backwards compatibility checks applied.