### PR TITLE
feat(eap): Add an endpoint to find traces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,7 +751,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.1.20"
+version = "0.1.22"
 dependencies = [
  "glob",
  "prost",

--- a/proto/sentry_protos/snuba/v1/endpoint_find_traces.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_find_traces.proto
@@ -12,10 +12,24 @@ enum TraceOrderBy {
   TRACE_ORDER_BY_TRACE_DURATION = 2;
 }
 
+message TracePageToken {
+  // This class exists to avoid circular imports with the PageToken class
+  // The next version of the proto will have a PageToken class that can be used
+  // for all endpoints, and this class can be removed.
+  oneof value {
+    uint64 offset = 1;
+    // Instead of using offset (which requires all the scanning and ordering),
+    // the server sends back a filter clause to be added on to the filter conditions
+    // which skips the previous results altogether, avoiding extra scanning and sorting
+    EventFilter event_filter = 2;
+    TraceFilter trace_filter = 3;
+  }
+}
+
 message FindTracesRequest {
   RequestMeta meta = 1;
   TraceFilter filter = 2;
-  PageToken page_token = 3;
+  TracePageToken page_token = 3;
   TraceOrderBy order_by = 4;
 }
 
@@ -27,5 +41,35 @@ message TraceResponse {
 
 message FindTracesResponse {
   repeated TraceResponse traces = 1;
-  PageToken page_token = 2;
+  TracePageToken page_token = 2;
+}
+
+message EventFilter {
+  TraceItemName trace_item_name = 1;
+  TraceItemFilter filter = 2;
+}
+
+message AndTraceFilter {
+  repeated TraceFilter filters = 1;
+}
+
+message OrTraceFilter {
+  repeated TraceFilter filters = 1;
+}
+
+message NotTraceFilter {
+  repeated TraceFilter filters = 1;
+}
+
+// Represents a set of conditions for finding particular events
+// in a trace. Each EventFilter is meant to find one particular
+// type of event. Those can then be combined to find traces that
+// contain different combinations of events.
+message TraceFilter {
+  oneof filter {
+    AndTraceFilter and_filter = 1;
+    OrTraceFilter or_filter = 2;
+    NotTraceFilter not_filter = 3;
+    EventFilter event_filter = 4;
+  }
 }

--- a/proto/sentry_protos/snuba/v1/endpoint_find_traces.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_find_traces.proto
@@ -1,0 +1,45 @@
+syntax = "proto3";
+
+package sentry_protos.snuba.v1;
+
+import "sentry_protos/snuba/v1/request_common.proto";
+import "sentry_protos/snuba/v1/trace_item_filter.proto";
+
+message EventFilter {
+  string trace_item_name = 1;
+  TraceItemFilter filter = 2;
+}
+
+message AndTraceFilter {
+  repeated EventFilter filters = 1;
+}
+
+message OrTraceFilter {
+  repeated EventFilter filters = 1;
+}
+
+message NotTraceFilter {
+  repeated EventFilter filters = 1;
+}
+
+message TraceFilter {
+  oneof value {
+    AndTraceFilter and_filter = 1;
+    OrTraceFilter or_filter = 2;
+    NotTraceFilter not_filter = 3;
+    EventFilter event_filter = 4;
+  }
+}
+
+message FindTracesRequest {
+  RequestMeta meta = 1;
+  TraceFilter filter = 2;
+}
+
+message TraceResponse {
+  string trace_id = 1;
+}
+
+message FindTracesResponse {
+  repeated TraceResponse traces = 1;
+}

--- a/proto/sentry_protos/snuba/v1/endpoint_find_traces.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_find_traces.proto
@@ -6,27 +6,6 @@ import "google/protobuf/timestamp.proto";
 import "sentry_protos/snuba/v1/request_common.proto";
 import "sentry_protos/snuba/v1/trace_item_filter.proto";
 
-message AndTraceFilter {
-  repeated TraceFilter filters = 1;
-}
-
-message OrTraceFilter {
-  repeated TraceFilter filters = 1;
-}
-
-message NotTraceFilter {
-  repeated TraceFilter filters = 1;
-}
-
-message TraceFilter {
-  oneof filter {
-    AndTraceFilter and_filter = 1;
-    OrTraceFilter or_filter = 2;
-    NotTraceFilter not_filter = 3;
-    EventFilter event_filter = 4;
-  }
-}
-
 message FindTracesRequest {
   RequestMeta meta = 1;
   TraceFilter filter = 2;

--- a/proto/sentry_protos/snuba/v1/endpoint_find_traces.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_find_traces.proto
@@ -6,11 +6,6 @@ import "google/protobuf/timestamp.proto";
 import "sentry_protos/snuba/v1/request_common.proto";
 import "sentry_protos/snuba/v1/trace_item_filter.proto";
 
-message EventFilter {
-  string trace_item_name = 1;
-  TraceItemFilter filter = 2;
-}
-
 message AndTraceFilter {
   repeated TraceFilter filters = 1;
 }

--- a/proto/sentry_protos/snuba/v1/endpoint_find_traces.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_find_traces.proto
@@ -6,7 +6,7 @@ import "google/protobuf/timestamp.proto";
 import "sentry_protos/snuba/v1/request_common.proto";
 import "sentry_protos/snuba/v1/trace_item_filter.proto";
 
-message TraceFilter {
+message EventFilter {
   string trace_item_name = 1;
   TraceItemFilter filter = 2;
 }
@@ -23,15 +23,19 @@ message NotTraceFilter {
   repeated TraceFilter filters = 1;
 }
 
-message FindTracesRequest {
+message TraceFilter {
   oneof filter {
     AndTraceFilter and_filter = 1;
     OrTraceFilter or_filter = 2;
     NotTraceFilter not_filter = 3;
-    TraceFilter event_filter = 4;
+    EventFilter event_filter = 4;
   }
-  RequestMeta meta = 5;
-  PageToken page_token = 6;
+}
+
+message FindTracesRequest {
+  RequestMeta meta = 1;
+  TraceFilter filter = 2;
+  PageToken page_token = 3;
 }
 
 message TraceResponse {

--- a/proto/sentry_protos/snuba/v1/endpoint_find_traces.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_find_traces.proto
@@ -2,44 +2,45 @@ syntax = "proto3";
 
 package sentry_protos.snuba.v1;
 
+import "google/protobuf/timestamp.proto";
 import "sentry_protos/snuba/v1/request_common.proto";
 import "sentry_protos/snuba/v1/trace_item_filter.proto";
 
-message EventFilter {
+message TraceFilter {
   string trace_item_name = 1;
   TraceItemFilter filter = 2;
 }
 
 message AndTraceFilter {
-  repeated EventFilter filters = 1;
+  repeated TraceFilter filters = 1;
 }
 
 message OrTraceFilter {
-  repeated EventFilter filters = 1;
+  repeated TraceFilter filters = 1;
 }
 
 message NotTraceFilter {
-  repeated EventFilter filters = 1;
-}
-
-message TraceFilter {
-  oneof value {
-    AndTraceFilter and_filter = 1;
-    OrTraceFilter or_filter = 2;
-    NotTraceFilter not_filter = 3;
-    EventFilter event_filter = 4;
-  }
+  repeated TraceFilter filters = 1;
 }
 
 message FindTracesRequest {
-  RequestMeta meta = 1;
-  TraceFilter filter = 2;
+  oneof filter {
+    AndTraceFilter and_filter = 1;
+    OrTraceFilter or_filter = 2;
+    NotTraceFilter not_filter = 3;
+    TraceFilter event_filter = 4;
+  }
+  RequestMeta meta = 5;
+  PageToken page_token = 6;
 }
 
 message TraceResponse {
   string trace_id = 1;
+  google.protobuf.Timestamp start_timestamp = 5;
+  google.protobuf.Timestamp end_timestamp = 6;
 }
 
 message FindTracesResponse {
   repeated TraceResponse traces = 1;
+  PageToken page_token = 2;
 }

--- a/proto/sentry_protos/snuba/v1/endpoint_find_traces.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_find_traces.proto
@@ -6,10 +6,17 @@ import "google/protobuf/timestamp.proto";
 import "sentry_protos/snuba/v1/request_common.proto";
 import "sentry_protos/snuba/v1/trace_item_filter.proto";
 
+enum TraceOrderBy {
+  TRACE_ORDER_BY_UNSPECIFIED = 0;
+  TRACE_ORDER_BY_END_TIME = 1;
+  TRACE_ORDER_BY_TRACE_DURATION = 2;
+}
+
 message FindTracesRequest {
   RequestMeta meta = 1;
   TraceFilter filter = 2;
   PageToken page_token = 3;
+  TraceOrderBy order_by = 4;
 }
 
 message TraceResponse {

--- a/proto/sentry_protos/snuba/v1/examples.py
+++ b/proto/sentry_protos/snuba/v1/examples.py
@@ -279,15 +279,17 @@ def test_example_find_traces() -> None:
     FindTracesRequest(
         meta=COMMON_META,
         filter=TraceFilter(
-            trace_item_name="spans",
-            filter=TraceItemFilter(
-                comparison_filter=ComparisonFilter(
-                    key=AttributeKey(
-                        type=AttributeKey.TYPE_STRING,
-                        name="sentry.span_name",
+            event_filter=EventFilter(
+                trace_item_name="spans",
+                filter=TraceItemFilter(
+                    comparison_filter=ComparisonFilter(
+                        key=AttributeKey(
+                            type=AttributeKey.TYPE_STRING,
+                            name="sentry.span_name",
+                        ),
+                        op=ComparisonFilter.OP_EQUALS,
+                        value=AttributeValue(val_str="database_query"),
                     ),
-                    op=ComparisonFilter.OP_EQUALS,
-                    value=AttributeValue(val_str="database_query"),
                 ),
             ),
         ),
@@ -298,27 +300,29 @@ def test_example_find_traces() -> None:
     FindTracesRequest(
         meta=COMMON_META,
         filter=TraceFilter(
-            trace_item_name="spans",
-            filter=TraceItemFilter(
-                and_filter=AndFilter(
-                    filters=[
-                        ComparisonFilter(
-                            key=AttributeKey(
-                                type=AttributeKey.TYPE_STRING,
-                                name="sentry.span_name",
+            event_filter=EventFilter(
+                trace_item_name="spans",
+                filter=TraceItemFilter(
+                    and_filter=AndFilter(
+                        filters=[
+                            ComparisonFilter(
+                                key=AttributeKey(
+                                    type=AttributeKey.TYPE_STRING,
+                                    name="sentry.span_name",
+                                ),
+                                op=ComparisonFilter.OP_EQUALS,
+                                value=AttributeValue(val_str="database_query"),
                             ),
-                            op=ComparisonFilter.OP_EQUALS,
-                            value=AttributeValue(val_str="database_query"),
-                        ),
-                        ComparisonFilter(
-                            key=AttributeKey(
-                                type=AttributeKey.TYPE_STRING,
-                                name="sentry.transaction_name",
+                            ComparisonFilter(
+                                key=AttributeKey(
+                                    type=AttributeKey.TYPE_STRING,
+                                    name="sentry.transaction_name",
+                                ),
+                                op=ComparisonFilter.OP_EQUALS,
+                                value=AttributeValue(val_str="GET /v1/rpc"),
                             ),
-                            op=ComparisonFilter.OP_EQUALS,
-                            value=AttributeValue(val_str="GET /v1/rpc"),
-                        ),
-                    ]
+                        ]
+                    ),
                 ),
             ),
         ),
@@ -328,35 +332,41 @@ def test_example_find_traces() -> None:
     # "database_query" and an error with a `group_id` of "1123"
     FindTracesRequest(
         meta=COMMON_META,
-        filter=AndTraceFilter(
-            filters=[
-                TraceFilter(
-                    trace_item_name="spans",
-                    filter=TraceItemFilter(
-                        comparison_filter=ComparisonFilter(
-                            key=AttributeKey(
-                                type=AttributeKey.TYPE_STRING,
-                                name="sentry.span_name",
+        filter=TraceFilter(
+            and_filter=AndTraceFilter(
+                filters=[
+                    TraceFilter(
+                        event_filter=EventFilter(
+                            trace_item_name="spans",
+                            filter=TraceItemFilter(
+                                comparison_filter=ComparisonFilter(
+                                    key=AttributeKey(
+                                        type=AttributeKey.TYPE_STRING,
+                                        name="sentry.span_name",
+                                    ),
+                                    op=ComparisonFilter.OP_EQUALS,
+                                    value=AttributeValue(val_str="database_query"),
+                                ),
                             ),
-                            op=ComparisonFilter.OP_EQUALS,
-                            value=AttributeValue(val_str="database_query"),
                         ),
                     ),
-                ),
-                TraceFilter(
-                    trace_item_name="errors",
-                    filter=TraceItemFilter(
-                        comparison_filter=ComparisonFilter(
-                            key=AttributeKey(
-                                type=AttributeKey.TYPE_STRING,
-                                name="group_id",
+                    TraceFilter(
+                        event_filter=EventFilter(
+                            trace_item_name="errors",
+                            filter=TraceItemFilter(
+                                comparison_filter=ComparisonFilter(
+                                    key=AttributeKey(
+                                        type=AttributeKey.TYPE_STRING,
+                                        name="group_id",
+                                    ),
+                                    op=ComparisonFilter.OP_EQUALS,
+                                    value=AttributeValue(val_str="1123"),
+                                ),
                             ),
-                            op=ComparisonFilter.OP_EQUALS,
-                            value=AttributeValue(val_str="1123"),
                         ),
                     ),
-                ),
-            ],
+                ],
+            ),
         ),
     )
 
@@ -364,41 +374,63 @@ def test_example_find_traces() -> None:
     # "database_query" and an error with a `group_id` of "1123"
     FindTracesRequest(
         meta=COMMON_META,
-        filter=OrTraceFilter(
-            filters=[
-                TraceFilter(
-                    trace_item_name="spans",
-                    filter=TraceItemFilter(
-                        comparison_filter=ComparisonFilter(
-                            key=AttributeKey(
-                                type=AttributeKey.TYPE_STRING,
-                                name="sentry.span_name",
+        filter=TraceFilter(
+            or_filter=OrTraceFilter(
+                filters=[
+                    TraceFilter(
+                        event_filter=EventFilter(
+                            trace_item_name="spans",
+                            filter=TraceItemFilter(
+                                comparison_filter=ComparisonFilter(
+                                    key=AttributeKey(
+                                        type=AttributeKey.TYPE_STRING,
+                                        name="sentry.span_name",
+                                    ),
+                                    op=ComparisonFilter.OP_EQUALS,
+                                    value=AttributeValue(val_str="database_query"),
+                                ),
                             ),
-                            op=ComparisonFilter.OP_EQUALS,
-                            value=AttributeValue(val_str="database_query"),
                         ),
                     ),
-                ),
-                EventFilter(
-                    trace_item_name="errors",
-                    filter=TraceItemFilter(
-                        comparison_filter=ComparisonFilter(
-                            key=AttributeKey(
-                                type=AttributeKey.TYPE_STRING,
-                                name="group_id",
+                    TraceFilter(
+                        event_filter=EventFilter(
+                            trace_item_name="errors",
+                            filter=TraceItemFilter(
+                                comparison_filter=ComparisonFilter(
+                                    key=AttributeKey(
+                                        type=AttributeKey.TYPE_STRING,
+                                        name="group_id",
+                                    ),
+                                    op=ComparisonFilter.OP_EQUALS,
+                                    value=AttributeValue(val_str="1123"),
+                                ),
                             ),
-                            op=ComparisonFilter.OP_EQUALS,
-                            value=AttributeValue(val_str="1123"),
                         ),
                     ),
-                ),
-            ],
+                ],
+            ),
         ),
     )
 
     FindTracesResponse(
         traces=[
-            TraceResponse(trace_id="1234567890abcdef"),
-            TraceResponse(trace_id="fedcba0987654321"),
+            TraceResponse(
+                trace_id="1234567890abcdef",
+                start_timestamp=Timestamp(
+                    seconds=int(datetime(2024, 4, 20, 16, 20).timestamp())
+                ),
+                end_timestamp=Timestamp(
+                    seconds=int(datetime(2024, 4, 20, 17, 20).timestamp())
+                ),
+            ),
+            TraceResponse(
+                trace_id="fedcba0987654321",
+                start_timestamp=Timestamp(
+                    seconds=int(datetime(2024, 4, 20, 16, 20).timestamp())
+                ),
+                end_timestamp=Timestamp(
+                    seconds=int(datetime(2024, 4, 20, 17, 20).timestamp())
+                ),
+            ),
         ],
     )

--- a/proto/sentry_protos/snuba/v1/examples.py
+++ b/proto/sentry_protos/snuba/v1/examples.py
@@ -279,17 +279,15 @@ def test_example_find_traces() -> None:
     FindTracesRequest(
         meta=COMMON_META,
         filter=TraceFilter(
-            event_filter=EventFilter(
-                trace_item_name="spans",
-                filter=TraceItemFilter(
-                    comparison_filter=ComparisonFilter(
-                        key=AttributeKey(
-                            type=AttributeKey.TYPE_STRING,
-                            name="sentry.span_name",
-                        ),
-                        op=ComparisonFilter.OP_EQUALS,
-                        value=AttributeValue(val_str="database_query"),
+            trace_item_name="spans",
+            filter=TraceItemFilter(
+                comparison_filter=ComparisonFilter(
+                    key=AttributeKey(
+                        type=AttributeKey.TYPE_STRING,
+                        name="sentry.span_name",
                     ),
+                    op=ComparisonFilter.OP_EQUALS,
+                    value=AttributeValue(val_str="database_query"),
                 ),
             ),
         ),
@@ -300,29 +298,27 @@ def test_example_find_traces() -> None:
     FindTracesRequest(
         meta=COMMON_META,
         filter=TraceFilter(
-            event_filter=EventFilter(
-                trace_item_name="spans",
-                filter=TraceItemFilter(
-                    and_filter=AndFilter(
-                        filters=[
-                            ComparisonFilter(
-                                key=AttributeKey(
-                                    type=AttributeKey.TYPE_STRING,
-                                    name="sentry.span_name",
-                                ),
-                                op=ComparisonFilter.OP_EQUALS,
-                                value=AttributeValue(val_str="database_query"),
+            trace_item_name="spans",
+            filter=TraceItemFilter(
+                and_filter=AndFilter(
+                    filters=[
+                        ComparisonFilter(
+                            key=AttributeKey(
+                                type=AttributeKey.TYPE_STRING,
+                                name="sentry.span_name",
                             ),
-                            ComparisonFilter(
-                                key=AttributeKey(
-                                    type=AttributeKey.TYPE_STRING,
-                                    name="sentry.transaction_name",
-                                ),
-                                op=ComparisonFilter.OP_EQUALS,
-                                value=AttributeValue(val_str="GET /v1/rpc"),
+                            op=ComparisonFilter.OP_EQUALS,
+                            value=AttributeValue(val_str="database_query"),
+                        ),
+                        ComparisonFilter(
+                            key=AttributeKey(
+                                type=AttributeKey.TYPE_STRING,
+                                name="sentry.transaction_name",
                             ),
-                        ]
-                    ),
+                            op=ComparisonFilter.OP_EQUALS,
+                            value=AttributeValue(val_str="GET /v1/rpc"),
+                        ),
+                    ]
                 ),
             ),
         ),
@@ -332,37 +328,35 @@ def test_example_find_traces() -> None:
     # "database_query" and an error with a `group_id` of "1123"
     FindTracesRequest(
         meta=COMMON_META,
-        filter=TraceFilter(
-            and_filter=AndTraceFilter(
-                filters=[
-                    EventFilter(
-                        trace_item_name="spans",
-                        filter=TraceItemFilter(
-                            comparison_filter=ComparisonFilter(
-                                key=AttributeKey(
-                                    type=AttributeKey.TYPE_STRING,
-                                    name="sentry.span_name",
-                                ),
-                                op=ComparisonFilter.OP_EQUALS,
-                                value=AttributeValue(val_str="database_query"),
+        filter=AndTraceFilter(
+            filters=[
+                TraceFilter(
+                    trace_item_name="spans",
+                    filter=TraceItemFilter(
+                        comparison_filter=ComparisonFilter(
+                            key=AttributeKey(
+                                type=AttributeKey.TYPE_STRING,
+                                name="sentry.span_name",
                             ),
+                            op=ComparisonFilter.OP_EQUALS,
+                            value=AttributeValue(val_str="database_query"),
                         ),
                     ),
-                    EventFilter(
-                        trace_item_name="errors",
-                        filter=TraceItemFilter(
-                            comparison_filter=ComparisonFilter(
-                                key=AttributeKey(
-                                    type=AttributeKey.TYPE_STRING,
-                                    name="group_id",
-                                ),
-                                op=ComparisonFilter.OP_EQUALS,
-                                value=AttributeValue(val_str="1123"),
+                ),
+                TraceFilter(
+                    trace_item_name="errors",
+                    filter=TraceItemFilter(
+                        comparison_filter=ComparisonFilter(
+                            key=AttributeKey(
+                                type=AttributeKey.TYPE_STRING,
+                                name="group_id",
                             ),
+                            op=ComparisonFilter.OP_EQUALS,
+                            value=AttributeValue(val_str="1123"),
                         ),
                     ),
-                ],
-            ),
+                ),
+            ],
         ),
     )
 
@@ -370,37 +364,35 @@ def test_example_find_traces() -> None:
     # "database_query" and an error with a `group_id` of "1123"
     FindTracesRequest(
         meta=COMMON_META,
-        filter=TraceFilter(
-            and_filter=OrTraceFilter(
-                filters=[
-                    EventFilter(
-                        trace_item_name="spans",
-                        filter=TraceItemFilter(
-                            comparison_filter=ComparisonFilter(
-                                key=AttributeKey(
-                                    type=AttributeKey.TYPE_STRING,
-                                    name="sentry.span_name",
-                                ),
-                                op=ComparisonFilter.OP_EQUALS,
-                                value=AttributeValue(val_str="database_query"),
+        filter=OrTraceFilter(
+            filters=[
+                TraceFilter(
+                    trace_item_name="spans",
+                    filter=TraceItemFilter(
+                        comparison_filter=ComparisonFilter(
+                            key=AttributeKey(
+                                type=AttributeKey.TYPE_STRING,
+                                name="sentry.span_name",
                             ),
+                            op=ComparisonFilter.OP_EQUALS,
+                            value=AttributeValue(val_str="database_query"),
                         ),
                     ),
-                    EventFilter(
-                        trace_item_name="errors",
-                        filter=TraceItemFilter(
-                            comparison_filter=ComparisonFilter(
-                                key=AttributeKey(
-                                    type=AttributeKey.TYPE_STRING,
-                                    name="group_id",
-                                ),
-                                op=ComparisonFilter.OP_EQUALS,
-                                value=AttributeValue(val_str="1123"),
+                ),
+                EventFilter(
+                    trace_item_name="errors",
+                    filter=TraceItemFilter(
+                        comparison_filter=ComparisonFilter(
+                            key=AttributeKey(
+                                type=AttributeKey.TYPE_STRING,
+                                name="group_id",
                             ),
+                            op=ComparisonFilter.OP_EQUALS,
+                            value=AttributeValue(val_str="1123"),
                         ),
                     ),
-                ],
-            ),
+                ),
+            ],
         ),
     )
 

--- a/proto/sentry_protos/snuba/v1/examples.py
+++ b/proto/sentry_protos/snuba/v1/examples.py
@@ -21,18 +21,19 @@ from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import (
 from sentry_protos.snuba.v1.endpoint_find_traces_pb2 import (
     FindTracesRequest,
     FindTracesResponse,
-    EventFilter,
-    AndTraceFilter,
-    OrTraceFilter,
     TraceResponse,
-    TraceFilter,
+    TraceOrderBy,
 )
 from sentry_protos.snuba.v1.request_common_pb2 import (
     RequestMeta,
-    TraceItemName,
     PageToken,
 )
 from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
+    TraceItemName,
+    TraceFilter,
+    EventFilter,
+    AndTraceFilter,
+    OrTraceFilter,
     TraceItemFilter,
     ComparisonFilter,
     ExistsFilter,
@@ -280,7 +281,7 @@ def test_example_find_traces() -> None:
         meta=COMMON_META,
         filter=TraceFilter(
             event_filter=EventFilter(
-                trace_item_name="spans",
+                trace_item_name=TraceItemName.TRACE_ITEM_NAME_EAP_SPANS,
                 filter=TraceItemFilter(
                     comparison_filter=ComparisonFilter(
                         key=AttributeKey(
@@ -293,6 +294,7 @@ def test_example_find_traces() -> None:
                 ),
             ),
         ),
+        order_by=TraceOrderBy.TRACE_ORDER_BY_END_TIME,
     )
 
     # Find traces with a single span event with a `span_name` of "database_query"
@@ -301,7 +303,7 @@ def test_example_find_traces() -> None:
         meta=COMMON_META,
         filter=TraceFilter(
             event_filter=EventFilter(
-                trace_item_name="spans",
+                trace_item_name=TraceItemName.TRACE_ITEM_NAME_EAP_SPANS,
                 filter=TraceItemFilter(
                     and_filter=AndFilter(
                         filters=[
@@ -326,6 +328,7 @@ def test_example_find_traces() -> None:
                 ),
             ),
         ),
+        order_by=TraceOrderBy.TRACE_ORDER_BY_TRACE_DURATION,
     )
 
     # Find traces that contain two events: a span with a `span_name` of
@@ -337,7 +340,7 @@ def test_example_find_traces() -> None:
                 filters=[
                     TraceFilter(
                         event_filter=EventFilter(
-                            trace_item_name="spans",
+                            trace_item_name=TraceItemName.TRACE_ITEM_NAME_EAP_SPANS,
                             filter=TraceItemFilter(
                                 comparison_filter=ComparisonFilter(
                                     key=AttributeKey(
@@ -352,7 +355,7 @@ def test_example_find_traces() -> None:
                     ),
                     TraceFilter(
                         event_filter=EventFilter(
-                            trace_item_name="errors",
+                            trace_item_name=TraceItemName.TRACE_ITEM_NAME_EAP_ERRORS,
                             filter=TraceItemFilter(
                                 comparison_filter=ComparisonFilter(
                                     key=AttributeKey(
@@ -379,7 +382,7 @@ def test_example_find_traces() -> None:
                 filters=[
                     TraceFilter(
                         event_filter=EventFilter(
-                            trace_item_name="spans",
+                            trace_item_name=TraceItemName.TRACE_ITEM_NAME_EAP_SPANS,
                             filter=TraceItemFilter(
                                 comparison_filter=ComparisonFilter(
                                     key=AttributeKey(
@@ -394,7 +397,7 @@ def test_example_find_traces() -> None:
                     ),
                     TraceFilter(
                         event_filter=EventFilter(
-                            trace_item_name="errors",
+                            trace_item_name=TraceItemName.TRACE_ITEM_NAME_ERRORS,
                             filter=TraceItemFilter(
                                 comparison_filter=ComparisonFilter(
                                     key=AttributeKey(

--- a/proto/sentry_protos/snuba/v1/request_common.proto
+++ b/proto/sentry_protos/snuba/v1/request_common.proto
@@ -28,5 +28,8 @@ message PageToken {
     // the server sends back a filter clause to be added on to the filter conditions
     // which skips the previous results altogether, avoiding extra scanning and sorting
     TraceItemFilter filter_offset = 2;
+    // For cross event queries, the server sends back a filter clause that also
+    // specifies the trace item name.
+    EventFilter event_filter = 3;
   }
 }

--- a/proto/sentry_protos/snuba/v1/request_common.proto
+++ b/proto/sentry_protos/snuba/v1/request_common.proto
@@ -16,15 +16,10 @@ message RequestMeta {
   TraceItemName trace_item_name = 7;
 }
 
-enum TraceItemName {
-  TRACE_ITEM_NAME_UNSPECIFIED = 0;
-  TRACE_ITEM_NAME_EAP_SPANS = 1;
-}
-
 message PageToken {
   oneof value {
     uint64 offset = 1;
-    // Instead of using offset (which requires all the scanning and ordering,
+    // Instead of using offset (which requires all the scanning and ordering),
     // the server sends back a filter clause to be added on to the filter conditions
     // which skips the previous results altogether, avoiding extra scanning and sorting
     TraceItemFilter filter_offset = 2;

--- a/proto/sentry_protos/snuba/v1/request_common.proto
+++ b/proto/sentry_protos/snuba/v1/request_common.proto
@@ -16,6 +16,12 @@ message RequestMeta {
   TraceItemName trace_item_name = 7;
 }
 
+enum TraceItemName {
+  TRACE_ITEM_NAME_UNSPECIFIED = 0;
+  TRACE_ITEM_NAME_EAP_SPANS = 1;
+  TRACE_ITEM_NAME_EAP_ERRORS = 2;
+}
+
 message PageToken {
   oneof value {
     uint64 offset = 1;
@@ -23,8 +29,5 @@ message PageToken {
     // the server sends back a filter clause to be added on to the filter conditions
     // which skips the previous results altogether, avoiding extra scanning and sorting
     TraceItemFilter filter_offset = 2;
-    // For cross event queries, the server sends back a filter clause that also
-    // specifies the trace item name.
-    EventFilter event_filter = 3;
   }
 }

--- a/proto/sentry_protos/snuba/v1/trace_item_filter.proto
+++ b/proto/sentry_protos/snuba/v1/trace_item_filter.proto
@@ -50,3 +50,10 @@ message TraceItemFilter {
     ExistsFilter exists_filter = 5;
   }
 }
+
+// Wraps a TraceItemFilter and specifies the trace item name,
+// to be used for cross-event queries.
+message EventFilter {
+  string trace_item_name = 1;
+  TraceItemFilter filter = 2;
+}

--- a/proto/sentry_protos/snuba/v1/trace_item_filter.proto
+++ b/proto/sentry_protos/snuba/v1/trace_item_filter.proto
@@ -4,12 +4,6 @@ package sentry_protos.snuba.v1;
 
 import "sentry_protos/snuba/v1/trace_item_attribute.proto";
 
-enum TraceItemName {
-  TRACE_ITEM_NAME_UNSPECIFIED = 0;
-  TRACE_ITEM_NAME_EAP_SPANS = 1;
-  TRACE_ITEM_NAME_EAP_ERRORS = 2;
-}
-
 message AndFilter {
   repeated TraceItemFilter filters = 1;
 }
@@ -54,37 +48,5 @@ message TraceItemFilter {
     NotFilter not_filter = 3;
     ComparisonFilter comparison_filter = 4;
     ExistsFilter exists_filter = 5;
-  }
-}
-
-// Wraps a TraceItemFilter and specifies the trace item name,
-// to be used for cross-event queries.
-message EventFilter {
-  TraceItemName trace_item_name = 1;
-  TraceItemFilter filter = 2;
-}
-
-message AndTraceFilter {
-  repeated TraceFilter filters = 1;
-}
-
-message OrTraceFilter {
-  repeated TraceFilter filters = 1;
-}
-
-message NotTraceFilter {
-  repeated TraceFilter filters = 1;
-}
-
-// Represents a set of conditions for finding particular events
-// in a trace. Each EventFilter is meant to find one particular
-// type of event. Those can then be combined to find traces that
-// contain different combinations of events.
-message TraceFilter {
-  oneof filter {
-    AndTraceFilter and_filter = 1;
-    OrTraceFilter or_filter = 2;
-    NotTraceFilter not_filter = 3;
-    EventFilter event_filter = 4;
   }
 }

--- a/proto/sentry_protos/snuba/v1/trace_item_filter.proto
+++ b/proto/sentry_protos/snuba/v1/trace_item_filter.proto
@@ -4,6 +4,12 @@ package sentry_protos.snuba.v1;
 
 import "sentry_protos/snuba/v1/trace_item_attribute.proto";
 
+enum TraceItemName {
+  TRACE_ITEM_NAME_UNSPECIFIED = 0;
+  TRACE_ITEM_NAME_EAP_SPANS = 1;
+  TRACE_ITEM_NAME_EAP_ERRORS = 2;
+}
+
 message AndFilter {
   repeated TraceItemFilter filters = 1;
 }
@@ -54,7 +60,7 @@ message TraceItemFilter {
 // Wraps a TraceItemFilter and specifies the trace item name,
 // to be used for cross-event queries.
 message EventFilter {
-  string trace_item_name = 1;
+  TraceItemName trace_item_name = 1;
   TraceItemFilter filter = 2;
 }
 

--- a/proto/sentry_protos/snuba/v1/trace_item_filter.proto
+++ b/proto/sentry_protos/snuba/v1/trace_item_filter.proto
@@ -57,3 +57,28 @@ message EventFilter {
   string trace_item_name = 1;
   TraceItemFilter filter = 2;
 }
+
+message AndTraceFilter {
+  repeated TraceFilter filters = 1;
+}
+
+message OrTraceFilter {
+  repeated TraceFilter filters = 1;
+}
+
+message NotTraceFilter {
+  repeated TraceFilter filters = 1;
+}
+
+// Represents a set of conditions for finding particular events
+// in a trace. Each EventFilter is meant to find one particular
+// type of event. Those can then be combined to find traces that
+// contain different combinations of events.
+message TraceFilter {
+  oneof filter {
+    AndTraceFilter and_filter = 1;
+    OrTraceFilter or_filter = 2;
+    NotTraceFilter not_filter = 3;
+    EventFilter event_filter = 4;
+  }
+}


### PR DESCRIPTION
This endpoint allows finding traces that contain events with specific attributes.

The TraceFilter and TraceItemFilter can be combined to search using multiple events,
and multiple attributes on each event.
