### PR TITLE
Add QueryStats and QueryMetadata to TraceItemTableResponse

### DIFF
--- a/proto/sentry_protos/snuba/v1/endpoint_time_series.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_time_series.proto
@@ -36,4 +36,5 @@ message TimeSeries {
 
 message TimeSeriesResponse {
   repeated TimeSeries result_timeseries = 1;
+  ResponseMeta meta = 5;
 }

--- a/proto/sentry_protos/snuba/v1/endpoint_trace_item_attributes.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_trace_item_attributes.proto
@@ -42,4 +42,5 @@ message TraceItemAttributeValuesRequest {
 message TraceItemAttributeValuesResponse {
   repeated string values = 1;
   PageToken page_token = 6;
+  ResponseMeta meta = 7;
 }

--- a/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
@@ -21,7 +21,6 @@ message TraceItemTableRequest {
   uint32 limit = 6;
   PageToken page_token = 7;
   repeated VirtualColumnContext virtual_column_contexts = 8;
-  bool debug = 10;
 }
 
 message Column {
@@ -40,6 +39,5 @@ message TraceItemColumnValues {
 message TraceItemTableResponse {
   repeated TraceItemColumnValues column_values = 1;
   PageToken page_token = 2;
-  optional QueryStats query_stats = 3;
-  optional QueryMetadata query_metadata = 4;
+  ResponseMeta meta = 3;
 }

--- a/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
@@ -21,6 +21,7 @@ message TraceItemTableRequest {
   uint32 limit = 6;
   PageToken page_token = 7;
   repeated VirtualColumnContext virtual_column_contexts = 8;
+  bool debug = 10;
 }
 
 message Column {

--- a/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
@@ -39,4 +39,6 @@ message TraceItemColumnValues {
 message TraceItemTableResponse {
   repeated TraceItemColumnValues column_values = 1;
   PageToken page_token = 2;
+  optional QueryStats query_stats = 3;
+  optional QueryMetadata query_metadata = 4;
 }

--- a/proto/sentry_protos/snuba/v1/request_common.proto
+++ b/proto/sentry_protos/snuba/v1/request_common.proto
@@ -33,13 +33,11 @@ message PageToken {
 
 message QueryStats {
   int64 rows_read = 1;
-  int64 bytes_read = 2;
-  double time_spent = 3;
+  int64 columns_read = 2;
   int32 blocks = 4;
   int64 progress_bytes = 5;
-  int32 result_rows = 6;
-  int32 result_cols = 7;
   int32 max_threads = 8;
+  TimingMarks timing_marks = 11;
 }
 
 message QueryMetadata {
@@ -49,8 +47,13 @@ message QueryMetadata {
   bool final = 4;
   string query_id = 6;
   bool consistent = 7;
-  string referrer = 8;
   bool cache_hit = 9;
   string cluster_name = 10;
-  map<string, int64> timing_marks = 11;
+}
+
+message TimingMarks {
+  int64 duration_ms = 1;
+  map<string, int64> marks_ms = 2;
+  map<string, string> tags = 3;
+  int64 timestamp = 4;
 }

--- a/proto/sentry_protos/snuba/v1/request_common.proto
+++ b/proto/sentry_protos/snuba/v1/request_common.proto
@@ -30,3 +30,27 @@ message PageToken {
     TraceItemFilter filter_offset = 2;
   }
 }
+
+message QueryStats {
+  int64 rows_read = 1;
+  int64 bytes_read = 2;
+  double time_spent = 3;
+  int32 blocks = 4;
+  int64 progress_bytes = 5;
+  int32 result_rows = 6;
+  int32 result_cols = 7;
+  int32 max_threads = 8;
+}
+
+message QueryMetadata {
+  string sql = 1;
+  string status = 2;
+  string clickhouse_table = 3;
+  bool final = 4;
+  string query_id = 6;
+  bool consistent = 7;
+  string referrer = 8;
+  bool cache_hit = 9;
+  string cluster_name = 10;
+  map<string, int64> timing_marks = 11;
+}

--- a/proto/sentry_protos/snuba/v1/request_common.proto
+++ b/proto/sentry_protos/snuba/v1/request_common.proto
@@ -20,9 +20,8 @@ message RequestMeta {
 
 message ResponseMeta {
   string request_id = 1;
-  // Optional fields that are included only if debug is true
-  repeated QueryStats query_stats = 3;
-  repeated QueryMetadata query_metadata = 4;
+  // Optional field that is included only if debug is true
+  repeated QueryInfo query_info = 2;
 }
 
 enum TraceItemName {
@@ -65,4 +64,9 @@ message TimingMarks {
   map<string, int64> marks_ms = 2;
   map<string, string> tags = 3;
   int64 timestamp = 4;
+}
+
+message QueryInfo {
+  QueryStats stats = 1;
+  QueryMetadata metadata = 2;
 }

--- a/proto/sentry_protos/snuba/v1/request_common.proto
+++ b/proto/sentry_protos/snuba/v1/request_common.proto
@@ -14,6 +14,15 @@ message RequestMeta {
   google.protobuf.Timestamp start_timestamp = 5;
   google.protobuf.Timestamp end_timestamp = 6;
   TraceItemName trace_item_name = 7;
+  bool debug = 10;
+  string request_id = 11;
+}
+
+message ResponseMeta {
+  string request_id = 1;
+  // Optional fields that are included only if debug is true
+  repeated QueryStats query_stats = 3;
+  repeated QueryMetadata query_metadata = 4;
 }
 
 enum TraceItemName {


### PR DESCRIPTION
Add QueryStats and QueryMetadata to API endpoints response

    - Update proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
      to include optional QueryStats and QueryMetadata fields in
      TraceItemTableResponse
    - Modify proto/sentry_protos/snuba/v1/request_common.proto
      to define QueryStats and QueryMetadata message structures

    These changes allow for more detailed query execution information
    to be included in responses, enhancing observability and debugging capabilities.