### PR TITLE
Add trace logging support to ResponseMeta

### DIFF
--- a/proto/sentry_protos/snuba/v1/request_common.proto
+++ b/proto/sentry_protos/snuba/v1/request_common.proto
@@ -16,6 +16,7 @@ message RequestMeta {
   TraceItemName trace_item_name = 7;
   bool debug = 10;
   string request_id = 11;
+  bool enable_trace_logs = 12;
 }
 
 message ResponseMeta {
@@ -70,4 +71,5 @@ message TimingMarks {
 message QueryInfo {
   QueryStats stats = 1;
   QueryMetadata metadata = 2;
+  string trace_logs = 3;
 }

--- a/proto/sentry_protos/snuba/v1/request_common.proto
+++ b/proto/sentry_protos/snuba/v1/request_common.proto
@@ -16,7 +16,6 @@ message RequestMeta {
   TraceItemName trace_item_name = 7;
   bool debug = 10;
   string request_id = 11;
-  bool enable_trace_logs = 12;
 }
 
 message ResponseMeta {


### PR DESCRIPTION
This commit introduces trace logging functionality:

- Added `trace_log` string field to ResponseMeta

These changes allow clients to request trace logging for their queries and receive the clickhouse trace logs in the response. This feature will help with debugging and performance analysis of EAP API.