### PR TITLE
Use AttributeKey in TraceItemAttributeValuesRequest

### DIFF
--- a/proto/sentry_protos/snuba/v1/endpoint_trace_item_attributes.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_trace_item_attributes.proto
@@ -31,7 +31,8 @@ message TraceItemAttributeNamesResponse {
 // to get all the possible values of a numerical attribute
 message TraceItemAttributeValuesRequest {
   RequestMeta meta = 1;
-  string name = 3;
+  AttributeKey key = 2;
+  deprecated string name = 3 [deprecated = true]; //  use the `key` field instead, for API consistency
   // a substring of the value being searched,
   // only strict substring supported, no regex
   string value_substring_match = 4;

--- a/proto/sentry_protos/snuba/v1/endpoint_trace_item_attributes.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_trace_item_attributes.proto
@@ -32,7 +32,7 @@ message TraceItemAttributeNamesResponse {
 message TraceItemAttributeValuesRequest {
   RequestMeta meta = 1;
   AttributeKey key = 2;
-  deprecated string name = 3 [deprecated = true]; //  use the `key` field instead, for API consistency
+  string name = 3 [deprecated = true]; //  use the `key` field instead, for API consistency
   // a substring of the value being searched,
   // only strict substring supported, no regex
   string value_substring_match = 4;


### PR DESCRIPTION
Instead of using the `name` field which is a raw string, since we're looking values of a specific attribute, use the attribute key instead.