### PR TITLE
feat: Run examples as tests and add tests for taskworker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,7 @@ jobs:
       - name: build rust bindings
         run: |
           make build-rust
+
+      - name: run python tests/examples
+        run: |
+          make test-py

--- a/Makefile
+++ b/Makefile
@@ -59,3 +59,8 @@ docs:
 	pip install sabledocs
 	protoc ./proto/sentry_protos/*/*/*.proto -I ./proto/ -o ./docs/descriptor.pb --include_source_info
 	cd docs && sabledocs
+
+.PHONY: test-py
+test-py:
+	cd py && pip install -e .
+	pytest tests/

--- a/Makefile
+++ b/Makefile
@@ -63,4 +63,4 @@ docs:
 .PHONY: test-py
 test-py:
 	cd py && pip install -e .
-	pytest tests/
+	pytest py/tests/

--- a/py/tests/test_snuba_v1.py
+++ b/py/tests/test_snuba_v1.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 from google.protobuf.timestamp_pb2 import Timestamp
 from sentry_protos.snuba.v1.endpoint_time_series_pb2 import (
+    DataPoint,
     TimeSeries,
     TimeSeriesRequest,
     TimeSeriesResponse,
@@ -31,13 +32,16 @@ from sentry_protos.snuba.v1.endpoint_trace_item_table_subscription_pb2 import (
 from sentry_protos.snuba.v1.request_common_pb2 import (
     RequestMeta,
     PageToken,
-)
-from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
     TraceItemName,
+)
+from sentry_protos.snuba.v1.endpoint_find_traces_pb2 import (
     TraceFilter,
     EventFilter,
     AndTraceFilter,
     OrTraceFilter,
+)
+
+from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
     TraceItemFilter,
     ComparisonFilter,
     ExistsFilter,
@@ -93,7 +97,7 @@ def test_example_time_series():
                     "consumer_group": "snuba_outcomes_consumer",
                 },
                 buckets=[COMMON_META.start_timestamp for _ in range(60)],
-                data_points=[42 for _ in range(60)],
+                data_points=[DataPoint(data=42) for _ in range(60)],
                 num_events=1337,
                 avg_sampling_rate=0.1,
             ),
@@ -104,7 +108,7 @@ def test_example_time_series():
                     "consumer_group": "snuba_outcomes_consumer",
                 },
                 buckets=[COMMON_META.start_timestamp for _ in range(60)],
-                data_points=[42 for _ in range(60)],
+                data_points=[DataPoint(data=42) for _ in range(60)],
                 num_events=1337,
                 avg_sampling_rate=0.1,
             ),
@@ -115,7 +119,7 @@ def test_example_time_series():
                     "consumer_group": "snuba_outcomes_consumer",
                 },
                 buckets=[COMMON_META.start_timestamp for _ in range(60)],
-                data_points=[42 for _ in range(60)],
+                data_points=[DataPoint(data=42) for _ in range(60)],
                 num_events=1337,
                 avg_sampling_rate=0.1,
             ),
@@ -126,7 +130,7 @@ def test_example_time_series():
                     "consumer_group": "snuba_outcomes_consumer",
                 },
                 buckets=[COMMON_META.start_timestamp for _ in range(60)],
-                data_points=[42 for _ in range(60)],
+                data_points=[DataPoint(data=42) for _ in range(60)],
                 num_events=1337,
                 avg_sampling_rate=0.1,
             ),
@@ -311,22 +315,26 @@ def test_example_find_traces() -> None:
                 filter=TraceItemFilter(
                     and_filter=AndFilter(
                         filters=[
-                            ComparisonFilter(
-                                key=AttributeKey(
-                                    type=AttributeKey.TYPE_STRING,
-                                    name="sentry.span_name",
+                            TraceItemFilter(
+                                comparison_filter=ComparisonFilter(
+                                    key=AttributeKey(
+                                        type=AttributeKey.TYPE_STRING,
+                                        name="sentry.span_name",
+                                    ),
+                                    op=ComparisonFilter.OP_EQUALS,
+                                    value=AttributeValue(val_str="database_query"),
                                 ),
-                                op=ComparisonFilter.OP_EQUALS,
-                                value=AttributeValue(val_str="database_query"),
                             ),
-                            ComparisonFilter(
-                                key=AttributeKey(
-                                    type=AttributeKey.TYPE_STRING,
-                                    name="sentry.transaction_name",
+                            TraceItemFilter(
+                                comparison_filter=ComparisonFilter(
+                                    key=AttributeKey(
+                                        type=AttributeKey.TYPE_STRING,
+                                        name="sentry.transaction_name",
+                                    ),
+                                    op=ComparisonFilter.OP_EQUALS,
+                                    value=AttributeValue(val_str="GET /v1/rpc"),
                                 ),
-                                op=ComparisonFilter.OP_EQUALS,
-                                value=AttributeValue(val_str="GET /v1/rpc"),
-                            ),
+                            )
                         ]
                     ),
                 ),
@@ -401,7 +409,7 @@ def test_example_find_traces() -> None:
                     ),
                     TraceFilter(
                         event_filter=EventFilter(
-                            trace_item_name=TraceItemName.TRACE_ITEM_NAME_ERRORS,
+                            trace_item_name=TraceItemName.TRACE_ITEM_NAME_EAP_ERRORS,
                             filter=TraceItemFilter(
                                 comparison_filter=ComparisonFilter(
                                     key=AttributeKey(

--- a/py/tests/test_taskworker_v1.py
+++ b/py/tests/test_taskworker_v1.py
@@ -1,0 +1,27 @@
+from datetime import datetime
+from google.protobuf.timestamp_pb2 import Timestamp
+from sentry_protos.sentry.v1.taskworker_pb2 import (
+    TaskActivation,
+    RetryState
+)
+
+now = datetime.now()
+
+
+def test_task_activation():
+    TaskActivation(
+        id="abc123",
+        namespace="integrations",
+        taskname="sentry.integrations.tasks.fetch_commits",
+        parameters='{"args": [1]}',
+        received_at=Timestamp(seconds=int(now.timestamp())),
+        retry_state=RetryState(
+            attempts=5,
+            kind="sentry.taskworker.retry.Retry",
+            discard_after_attempt=5,
+            deadletter_after_attempt=9
+        ),
+        processing_deadline_duration=5,
+        expires=500
+    )
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ mypy-protobuf==3.6.0
 mypy==1.10.1
 pre-commit==3.7.1
 black==24.4.2
+pytest==8.3.3


### PR DESCRIPTION
- Move examples into py/tests so that we can run them.
- Fix broken examples in snuba module.
- Add tests for taskworker protos
- Extend CI configuration to run python tests on generated code.

Refs #42