### PR TITLE
feat: add p75

### DIFF
--- a/proto/sentry_protos/snuba/v1/trace_item_attribute.proto
+++ b/proto/sentry_protos/snuba/v1/trace_item_attribute.proto
@@ -61,6 +61,7 @@ enum Function {
   FUNCTION_AVERAGE = 2 [deprecated = true];
   FUNCTION_COUNT = 3;
   FUNCTION_P50 = 4;
+  FUNCTION_P75 = 12;
   FUNCTION_P90 = 5;
   FUNCTION_P95 = 6;
   FUNCTION_P99 = 7;


### PR DESCRIPTION
- Not sure if we'd prefer to keep these ordered by their enum value, or by their names?