### PR TITLE
Use a reliability enum instead of boolean

### DIFF
--- a/proto/sentry_protos/snuba/v1/endpoint_time_series.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_time_series.proto
@@ -20,8 +20,9 @@ message DataPoint {
   // optional, if not set, assume true. Accounts for sparse time series
   bool data_present = 2;
   float avg_sampling_rate = 3;
-  bool is_reliable = 4;
-  // determines whether the aggregation is reliable using math based on confidence intervals and sample size
+  bool is_reliable = 4 [deprecated = true];
+  // determines the reliability of the aggregation using math based on confidence intervals and sample size
+  Reliability reliability = 5;
 }
 
 message TimeSeries {

--- a/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
@@ -34,6 +34,7 @@ message Column {
 message TraceItemColumnValues {
   string attribute_name = 1;
   repeated AttributeValue results = 2;
+  repeated Reliability reliabilities = 3;
 }
 
 message TraceItemTableResponse {

--- a/proto/sentry_protos/snuba/v1/trace_item_attribute.proto
+++ b/proto/sentry_protos/snuba/v1/trace_item_attribute.proto
@@ -86,6 +86,6 @@ message AttributeAggregation {
 
 enum Reliability {
   RELIABILITY_UNSPECIFIED = 0;
-  RELIABILITY_HIGH = 1;
-  RELIABILITY_LOW = 2;
+  RELIABILITY_LOW = 1;
+  RELIABILITY_HIGH = 2;
 }

--- a/proto/sentry_protos/snuba/v1/trace_item_attribute.proto
+++ b/proto/sentry_protos/snuba/v1/trace_item_attribute.proto
@@ -83,3 +83,9 @@ message AttributeAggregation {
   string label = 3;
   ExtrapolationMode extrapolation_mode = 4;
 }
+
+enum Reliability {
+  RELIABILITY_UNSPECIFIED = 0;
+  RELIABILITY_HIGH = 1;
+  RELIABILITY_LOW = 2;
+}


### PR DESCRIPTION
Adding a reliability enum to allow us to extend the reliability states in the future