### PR TITLE
ref(taskbroker) Add at_most_once flag to task activations

### DIFF
--- a/proto/sentry_protos/sentry/v1/taskworker.proto
+++ b/proto/sentry_protos/sentry/v1/taskworker.proto
@@ -17,6 +17,9 @@ message RetryState {
 
   // After this attempt the task should be put in the dead-letter-queue.
   optional int32 deadletter_after_attempt = 4;
+
+  // Whether a task should be executed at most once.
+  optional bool at_most_once = 5;
 }
 
 enum TaskActivationStatus {


### PR DESCRIPTION
Some tasks can be marked as being only executed at most once. Add a flag to denote that status.

Tasks with this status are guaranteed to execute 0 or 1 times. The worker uses this flag to
determine how it should handle the task.
