### PR TITLE
feat(taskbroker): Improve fetch_next

### DIFF
--- a/proto/sentry_protos/sentry/v1/taskworker.proto
+++ b/proto/sentry_protos/sentry/v1/taskworker.proto
@@ -126,7 +126,7 @@ message GetTaskResponse {
   optional Error error = 3;
 }
 
-message FetchNext {
+message FetchNextTask {
   optional string namespace = 1;
 }
 
@@ -135,7 +135,9 @@ message SetTaskStatusRequest {
   TaskActivationStatus status = 3;
 
   // If fetch_next is provided, receive a new task in the response
-  optional FetchNext fetch_next = 6;
+  optional bool fetch_next = 4 [deprecated = true];
+  optional string fetch_next_namespace = 5 [deprecated = true];
+  optional FetchNextTask fetch_next_task = 6;
 }
 
 message SetTaskStatusResponse {

--- a/proto/sentry_protos/sentry/v1/taskworker.proto
+++ b/proto/sentry_protos/sentry/v1/taskworker.proto
@@ -132,11 +132,12 @@ message FetchNext {
 
 message SetTaskStatusRequest {
   string id = 1;
-  TaskActivationStatus status = 2;
+  TaskActivationStatus status = 3;
 
   // If fetch_next is provided, receive a new task in the response
-  optional FetchNext fetch_next = 3;
+  optional FetchNext fetch_next = 6;
 }
+
 message SetTaskStatusResponse {
   // The next task the worker should execute. Requires fetch_next to be set on the request.
   optional TaskActivation task = 1;

--- a/proto/sentry_protos/sentry/v1/taskworker.proto
+++ b/proto/sentry_protos/sentry/v1/taskworker.proto
@@ -126,16 +126,19 @@ message GetTaskResponse {
   optional Error error = 3;
 }
 
+message FetchNext {
+  optional string namespace = 1;
+}
+
 message SetTaskStatusRequest {
   string id = 1;
-  TaskActivationStatus status = 3;
+  TaskActivationStatus status = 2;
 
-  // Set to true to have receive a new task in the response
-  optional bool fetch_next = 4;
-  optional string fetch_next_namespace = 5;
+  // If fetch_next is provided, receive a new task in the response
+  optional FetchNext fetch_next = 3;
 }
 message SetTaskStatusResponse {
-  // The next task the worker should execute. Requires fetch_next=True on the request.
+  // The next task the worker should execute. Requires fetch_next to be set on the request.
   optional TaskActivation task = 1;
 
   optional Error error = 3;


### PR DESCRIPTION
Enrich `fetch_next` type. By doing this, we would not run into the case where`fetch_next: bool` is not provided (or set to false) and `fetch_next_namespace: string` is provided. Now, either the fetch_next message is provided with an optional namespace, or not at all.