### PR TITLE
feat(eap): Add a GetTraces endpoint

### DIFF
--- a/proto/sentry_protos/snuba/v1/endpoint_find_traces.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_find_traces.proto
@@ -11,6 +11,9 @@ message TraceColumn {
     NAME_UNSPECIFIED = 0;
     NAME_TRACE_ID = 1;
     NAME_START_TIMESTAMP = 2;
+    NAME_ROOT_SPAN_NAME = 3;
+    NAME_TOTAL_SPAN_COUNT = 4;
+    NAME_FILTERED_SPAN_COUNT = 5;
   }
 
   Name name = 1;

--- a/proto/sentry_protos/snuba/v1/endpoint_find_traces.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_find_traces.proto
@@ -2,51 +2,74 @@ syntax = "proto3";
 
 package sentry_protos.snuba.v1;
 
+import "google/protobuf/timestamp.proto";
 import "sentry_protos/snuba/v1/request_common.proto";
-import "sentry_protos/snuba/v1/trace_item_attribute.proto";
 import "sentry_protos/snuba/v1/trace_item_filter.proto";
 
-message TraceColumn {
-  enum Name {
-    NAME_UNSPECIFIED = 0;
-    NAME_TRACE_ID = 1;
-    NAME_START_TIMESTAMP = 2;
-    NAME_ROOT_SPAN_NAME = 3;
-    NAME_TOTAL_SPAN_COUNT = 4;
-    NAME_FILTERED_SPAN_COUNT = 5;
-  }
+enum TraceOrderBy {
+  TRACE_ORDER_BY_UNSPECIFIED = 0;
+  TRACE_ORDER_BY_END_TIME = 1;
+  TRACE_ORDER_BY_TRACE_DURATION = 2;
+}
 
-  Name name = 1;
-  AttributeKey.Type type = 2;
+message TracePageToken {
+  // This class exists to avoid circular imports with the PageToken class
+  // The next version of the proto will have a PageToken class that can be used
+  // for all endpoints, and this class can be removed.
+  oneof value {
+    uint64 offset = 1;
+    // Instead of using offset (which requires all the scanning and ordering),
+    // the server sends back a filter clause to be added on to the filter conditions
+    // which skips the previous results altogether, avoiding extra scanning and sorting
+    EventFilter event_filter = 2;
+    TraceFilter trace_filter = 3;
+  }
 }
 
 message FindTracesRequest {
-  message OrderBy {
-    TraceColumn column = 1;
-    bool descending = 2;
-  }
-
   RequestMeta meta = 1;
-  TraceItemFilter filter = 2;
-  PageToken page_token = 3;
-  uint32 limit = 4;
+  TraceFilter filter = 2;
+  TracePageToken page_token = 3;
+  TraceOrderBy order_by = 4;
+}
 
-  repeated OrderBy order_by = 5;
-  repeated TraceColumn columns = 6;
+message TraceResponse {
+  string trace_id = 1;
+  google.protobuf.Timestamp start_timestamp = 5;
+  google.protobuf.Timestamp end_timestamp = 6;
 }
 
 message FindTracesResponse {
-  message Trace {
-    message Column {
-      TraceColumn.Name name = 1;
-      AttributeValue value = 2;
-    }
+  repeated TraceResponse traces = 1;
+  TracePageToken page_token = 2;
+}
 
-    repeated Column columns = 1;
+message EventFilter {
+  TraceItemName trace_item_name = 1;
+  TraceItemFilter filter = 2;
+}
+
+message AndTraceFilter {
+  repeated TraceFilter filters = 1;
+}
+
+message OrTraceFilter {
+  repeated TraceFilter filters = 1;
+}
+
+message NotTraceFilter {
+  repeated TraceFilter filters = 1;
+}
+
+// Represents a set of conditions for finding particular events
+// in a trace. Each EventFilter is meant to find one particular
+// type of event. Those can then be combined to find traces that
+// contain different combinations of events.
+message TraceFilter {
+  oneof filter {
+    AndTraceFilter and_filter = 1;
+    OrTraceFilter or_filter = 2;
+    NotTraceFilter not_filter = 3;
+    EventFilter event_filter = 4;
   }
-
-  repeated Trace traces = 1;
-
-  PageToken page_token = 2;
-  ResponseMeta meta = 3;
 }

--- a/proto/sentry_protos/snuba/v1/endpoint_find_traces.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_find_traces.proto
@@ -2,74 +2,48 @@ syntax = "proto3";
 
 package sentry_protos.snuba.v1;
 
-import "google/protobuf/timestamp.proto";
 import "sentry_protos/snuba/v1/request_common.proto";
+import "sentry_protos/snuba/v1/trace_item_attribute.proto";
 import "sentry_protos/snuba/v1/trace_item_filter.proto";
 
-enum TraceOrderBy {
-  TRACE_ORDER_BY_UNSPECIFIED = 0;
-  TRACE_ORDER_BY_END_TIME = 1;
-  TRACE_ORDER_BY_TRACE_DURATION = 2;
-}
-
-message TracePageToken {
-  // This class exists to avoid circular imports with the PageToken class
-  // The next version of the proto will have a PageToken class that can be used
-  // for all endpoints, and this class can be removed.
-  oneof value {
-    uint64 offset = 1;
-    // Instead of using offset (which requires all the scanning and ordering),
-    // the server sends back a filter clause to be added on to the filter conditions
-    // which skips the previous results altogether, avoiding extra scanning and sorting
-    EventFilter event_filter = 2;
-    TraceFilter trace_filter = 3;
+message TraceColumn {
+  enum Name {
+    NAME_UNSPECIFIED = 0;
+    NAME_TRACE_ID = 1;
+    NAME_START_TIMESTAMP = 2;
   }
+
+  Name name = 1;
+  AttributeKey.Type type = 2;
 }
 
 message FindTracesRequest {
-  RequestMeta meta = 1;
-  TraceFilter filter = 2;
-  TracePageToken page_token = 3;
-  TraceOrderBy order_by = 4;
-}
+  message OrderBy {
+    TraceColumn column = 1;
+    bool descending = 2;
+  }
 
-message TraceResponse {
-  string trace_id = 1;
-  google.protobuf.Timestamp start_timestamp = 5;
-  google.protobuf.Timestamp end_timestamp = 6;
+  RequestMeta meta = 1;
+  TraceItemFilter filter = 2;
+  PageToken page_token = 3;
+  uint32 limit = 4;
+
+  repeated OrderBy order_by = 5;
+  repeated TraceColumn columns = 6;
 }
 
 message FindTracesResponse {
-  repeated TraceResponse traces = 1;
-  TracePageToken page_token = 2;
-}
+  message Trace {
+    message Column {
+      TraceColumn.Name name = 1;
+      AttributeValue value = 2;
+    }
 
-message EventFilter {
-  TraceItemName trace_item_name = 1;
-  TraceItemFilter filter = 2;
-}
-
-message AndTraceFilter {
-  repeated TraceFilter filters = 1;
-}
-
-message OrTraceFilter {
-  repeated TraceFilter filters = 1;
-}
-
-message NotTraceFilter {
-  repeated TraceFilter filters = 1;
-}
-
-// Represents a set of conditions for finding particular events
-// in a trace. Each EventFilter is meant to find one particular
-// type of event. Those can then be combined to find traces that
-// contain different combinations of events.
-message TraceFilter {
-  oneof filter {
-    AndTraceFilter and_filter = 1;
-    OrTraceFilter or_filter = 2;
-    NotTraceFilter not_filter = 3;
-    EventFilter event_filter = 4;
+    repeated Column columns = 1;
   }
+
+  repeated Trace traces = 1;
+
+  PageToken page_token = 2;
+  ResponseMeta meta = 3;
 }

--- a/proto/sentry_protos/snuba/v1/endpoint_get_traces.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_get_traces.proto
@@ -34,7 +34,6 @@ message TraceAttribute {
   }
 
   Key key = 1;
-  AttributeKey.Type type = 2;
   AttributeValue value = 3;
 }
 

--- a/proto/sentry_protos/snuba/v1/endpoint_get_traces.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_get_traces.proto
@@ -6,24 +6,25 @@ import "sentry_protos/snuba/v1/request_common.proto";
 import "sentry_protos/snuba/v1/trace_item_attribute.proto";
 import "sentry_protos/snuba/v1/trace_item_filter.proto";
 
-message TraceColumn {
-  enum Name {
-    NAME_UNSPECIFIED = 0;
-    NAME_TRACE_ID = 1;
-    NAME_START_TIMESTAMP = 2;
-    NAME_ROOT_SPAN_NAME = 3;
-    NAME_TOTAL_SPAN_COUNT = 4;
-    NAME_FILTERED_SPAN_COUNT = 5;
-    NAME_ROOT_SPAN_DURATION_MS = 6;
-  }
+enum TraceAttributeKey {
+  TRACE_ATTRIBUTE_KEY_UNSPECIFIED = 0;
+  TRACE_ATTRIBUTE_KEY_TRACE_ID = 1;
+  TRACE_ATTRIBUTE_KEY_START_TIMESTAMP = 2;
+  TRACE_ATTRIBUTE_KEY_ROOT_SPAN_NAME = 3;
+  TRACE_ATTRIBUTE_KEY_TOTAL_SPAN_COUNT = 4;
+  TRACE_ATTRIBUTE_KEY_FILTERED_SPAN_COUNT = 5;
+  TRACE_ATTRIBUTE_KEY_ROOT_SPAN_DURATION_MS = 6;
+}
 
-  Name name = 1;
+message TraceAttribute {
+  TraceAttributeKey key = 1;
   AttributeKey.Type type = 2;
+  AttributeValue value = 3;
 }
 
 message GetTracesRequest {
   message OrderBy {
-    TraceColumn column = 1;
+    TraceAttributeKey key = 1;
     bool descending = 2;
   }
 
@@ -36,22 +37,17 @@ message GetTracesRequest {
   PageToken page_token = 2;
   uint32 limit = 3;
 
-  repeated TraceItemFilter filters = 4;
+  repeated TraceFilter filters = 4;
   repeated OrderBy order_by = 5;
-  repeated TraceColumn columns = 6;
+  repeated TraceAttribute attributes = 6;
 }
 
 message GetTracesResponse {
   message Trace {
-    message Column {
-      TraceColumn.Name name = 1;
-      AttributeValue value = 2;
-    }
-
-    repeated Column columns = 1;
+    repeated TraceAttribute attributes = 1;
   }
 
-  repeated Trace traces = 1;
+  repeated Trace rows = 1;
 
   PageToken page_token = 2;
   ResponseMeta meta = 3;

--- a/proto/sentry_protos/snuba/v1/endpoint_get_traces.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_get_traces.proto
@@ -34,7 +34,11 @@ message TraceAttribute {
   }
 
   Key key = 1;
-  AttributeValue value = 3;
+  AttributeValue value = 2;
+
+  // AttributeKey.Type will specify the type of the attribute we return.
+  // It does not need to be sent when requesting an attribute.
+  AttributeKey.Type type = 3;
 }
 
 // GetTracesRequest lets you query traces with various attributes.

--- a/proto/sentry_protos/snuba/v1/endpoint_get_traces.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_get_traces.proto
@@ -28,6 +28,9 @@ message TraceAttribute {
     // KEY_ROOT_SPAN_DURATION_MS will return the duration of the root span in
     // milliseconds.
     KEY_ROOT_SPAN_DURATION_MS = 6;
+    // KEY_ROOT_SPAN_PROJECT_ID returns the project ID associated with the root
+    // span.
+    KEY_ROOT_SPAN_PROJECT_ID = 7;
   }
 
   Key key = 1;

--- a/proto/sentry_protos/snuba/v1/endpoint_get_traces.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_get_traces.proto
@@ -1,0 +1,52 @@
+syntax = "proto3";
+
+package sentry_protos.snuba.v1;
+
+import "sentry_protos/snuba/v1/request_common.proto";
+import "sentry_protos/snuba/v1/trace_item_attribute.proto";
+import "sentry_protos/snuba/v1/trace_item_filter.proto";
+
+message TraceColumn {
+  enum Name {
+    NAME_UNSPECIFIED = 0;
+    NAME_TRACE_ID = 1;
+    NAME_START_TIMESTAMP = 2;
+    NAME_ROOT_SPAN_NAME = 3;
+    NAME_TOTAL_SPAN_COUNT = 4;
+    NAME_FILTERED_SPAN_COUNT = 5;
+  }
+
+  Name name = 1;
+  AttributeKey.Type type = 2;
+}
+
+message GetTracesRequest {
+  message OrderBy {
+    TraceColumn column = 1;
+    bool descending = 2;
+  }
+
+  RequestMeta meta = 1;
+  TraceItemFilter filter = 2;
+  PageToken page_token = 3;
+  uint32 limit = 4;
+
+  repeated OrderBy order_by = 5;
+  repeated TraceColumn columns = 6;
+}
+
+message GetTracesResponse {
+  message Trace {
+    message Column {
+      TraceColumn.Name name = 1;
+      AttributeValue value = 2;
+    }
+
+    repeated Column columns = 1;
+  }
+
+  repeated Trace traces = 1;
+
+  PageToken page_token = 2;
+  ResponseMeta meta = 3;
+}

--- a/proto/sentry_protos/snuba/v1/endpoint_get_traces.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_get_traces.proto
@@ -26,11 +26,16 @@ message GetTracesRequest {
     bool descending = 2;
   }
 
-  RequestMeta meta = 1;
-  TraceItemFilter filter = 2;
-  PageToken page_token = 3;
-  uint32 limit = 4;
+  message TraceFilter {
+    TraceItemName item_name = 1;
+    TraceItemFilter filter = 2;
+  }
 
+  RequestMeta meta = 1;
+  PageToken page_token = 2;
+  uint32 limit = 3;
+
+  repeated TraceItemFilter filters = 4;
   repeated OrderBy order_by = 5;
   repeated TraceColumn columns = 6;
 }

--- a/proto/sentry_protos/snuba/v1/endpoint_get_traces.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_get_traces.proto
@@ -6,29 +6,45 @@ import "sentry_protos/snuba/v1/request_common.proto";
 import "sentry_protos/snuba/v1/trace_item_attribute.proto";
 import "sentry_protos/snuba/v1/trace_item_filter.proto";
 
-enum TraceAttributeKey {
-  TRACE_ATTRIBUTE_KEY_UNSPECIFIED = 0;
-  TRACE_ATTRIBUTE_KEY_TRACE_ID = 1;
-  TRACE_ATTRIBUTE_KEY_START_TIMESTAMP = 2;
-  TRACE_ATTRIBUTE_KEY_ROOT_SPAN_NAME = 3;
-  TRACE_ATTRIBUTE_KEY_TOTAL_SPAN_COUNT = 4;
-  TRACE_ATTRIBUTE_KEY_FILTERED_SPAN_COUNT = 5;
-  TRACE_ATTRIBUTE_KEY_ROOT_SPAN_DURATION_MS = 6;
-}
-
+// TraceAttribute represents the attribute of a trace.
 message TraceAttribute {
-  TraceAttributeKey key = 1;
+  // Key lists the available trace attribute keys you can query.
+  enum Key {
+    KEY_UNSPECIFIED = 0;
+    KEY_TRACE_ID = 1;
+    // KEY_START_TIMESTAMP will return the earliest timestamp seen in the trace.
+    KEY_START_TIMESTAMP = 2;
+    // KEY_ROOT_SPAN_NAME will return the name of the root (segment) span of
+    // the trace.
+    KEY_ROOT_SPAN_NAME = 3;
+    // KEY_TOTAL_ITEM_COUNT will return the count of all the items in a trace,
+    // regardless of the conditions applied.
+    KEY_TOTAL_ITEM_COUNT = 4;
+    // KEY_FILTERED_ITEM_COUNT will return the count of items where the filters
+    // apply.
+    // For example, in a trace with 5 items (1 http.server span, 4 db spans),
+    // if we query for traces with span.op == "db", this will return 4.
+    KEY_FILTERED_ITEM_COUNT = 5;
+    // KEY_ROOT_SPAN_DURATION_MS will return the duration of the root span in
+    // milliseconds.
+    KEY_ROOT_SPAN_DURATION_MS = 6;
+  }
+
+  Key key = 1;
   AttributeKey.Type type = 2;
   AttributeValue value = 3;
 }
 
+// GetTracesRequest lets you query traces with various attributes.
 message GetTracesRequest {
   message OrderBy {
-    TraceAttributeKey key = 1;
+    TraceAttribute.Key key = 1;
     bool descending = 2;
   }
 
+  // TraceFilter specifies conditions to apply on the items contained in a trace.
   message TraceFilter {
+    // `item_name` is the item type we will apply the filter condition on.
     TraceItemName item_name = 1;
     TraceItemFilter filter = 2;
   }
@@ -37,18 +53,24 @@ message GetTracesRequest {
   PageToken page_token = 2;
   uint32 limit = 3;
 
+  // List of filters on items of the trace we'll use when querying.
   repeated TraceFilter filters = 4;
+  // List of attributes we'd like to order by.
   repeated OrderBy order_by = 5;
+  // List of attributes we want to query.
   repeated TraceAttribute attributes = 6;
 }
 
+// GetTracesResponse contains a list of traces returned by the request.
 message GetTracesResponse {
   message Trace {
+    // List of attributes queried.
     repeated TraceAttribute attributes = 1;
   }
 
-  repeated Trace rows = 1;
+  PageToken page_token = 1;
+  ResponseMeta meta = 2;
 
-  PageToken page_token = 2;
-  ResponseMeta meta = 3;
+  // List of traces matching conditions.
+  repeated Trace traces = 3;
 }

--- a/proto/sentry_protos/snuba/v1/endpoint_get_traces.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_get_traces.proto
@@ -14,6 +14,7 @@ message TraceColumn {
     NAME_ROOT_SPAN_NAME = 3;
     NAME_TOTAL_SPAN_COUNT = 4;
     NAME_FILTERED_SPAN_COUNT = 5;
+    NAME_ROOT_SPAN_DURATION_MS = 6;
   }
 
   Name name = 1;


### PR DESCRIPTION
This will add Protobuf files describing a new endpoint to find traces. It will return a list of traces with fields requested.

Features:
- You can pick which fields from the `enum`
- You can specify the type you want from a field
- You can use the same filter conditions as for the `TraceItemTable` endpoint
- You can order by any field from the `enum`

Limitations:
- No aggregation possible
- No support for alias
- A fixed list of fields to query

Since traces are not a defined object but a specific view on an aggregated list of spans, I don't think we should plan to support any field possible. Maybe at some point, we'll make the trace a real object and we'll add trace attributes and by then, we can design a new version of the endpoint.

Closes https://github.com/getsentry/eap-planning/issues/121.