### PR TITLE
chore: Update to buf-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,13 @@ jobs:
           ref: ${{ github.ref }}
       - uses: bufbuild/buf-setup-action@v1.34.0
 
-      - name: buf lint
-        run: |
-          buf lint
-
-      - name: buf breaking
-        uses: bufbuild/buf-breaking-action@v1
+      - name: buf lint and breaking
+        uses: bufbuild/buf-action@v1
         with:
-          against: 'https://github.com/getsentry/sentry-protos.git#branch=main'
+          lint: true
+          breaking: true
+          format: false
+          breaking_against: 'https://github.com/getsentry/sentry-protos.git#branch=main'
 
   codegen:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The buf-breaking action is deprecated and this moves us to the replacement. One benefit of the unified action is that it leaves PR comments for results.