### PR TITLE
feat: add ensure-protoc to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,9 +53,21 @@ update-vendor:
 .PHONY: build
 build: build-py build-rust
 
+# installs protoc if not already installed
+.PHONY: ensure-protoc
+ensure-protoc:
+	@which protoc >/dev/null 2>&1 || ( \
+		echo "Installing protoc..." && \
+		if [ "$$(uname)" = "Darwin" ]; then \
+			brew install protobuf; \
+		else \
+			echo "Error: Automatic protoc installation not supported on this OS, please install it manually"; \
+			exit 1; \
+		fi \
+	)
 
 .PHONY: docs
-docs:
+docs: ensure-protoc
 	pip install sabledocs
 	protoc ./proto/sentry_protos/*/*/*.proto -I ./proto/ -o ./docs/descriptor.pb --include_source_info
 	cd docs && sabledocs


### PR DESCRIPTION
I tried to run `make docs` locally but it failed bc i didnt have `protoc` installed. I added a target to the makefile that installs `protoc` if not installed. Now if you run `make docs` and dont have `protoc` installed, it installs it for you.