### PR TITLE
feat: no local commits to main branch

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,9 @@ repos:
         require_serial: true
         # These are generated, don't format them.
         exclude: ^py/
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.2.0
+    hooks:
+      - id: no-commit-to-branch
+        args: ['--branch', 'main']
+


### PR DESCRIPTION
currently we can do local git commits to `main` branch. this pr adds a pre-commit hook so we cant anymore.

idk if theres any branch protections on the remote repo