### PR TITLE
feat(eap): Add aggregation filter

### DIFF
--- a/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
@@ -36,6 +36,7 @@ message TraceItemTableRequest {
 
   repeated VirtualColumnContext virtual_column_contexts = 8;
 
+  // filter out results using aggregate functions
   AggregationFilter aggregation_filter = 9;
 }
 

--- a/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
@@ -35,6 +35,40 @@ message TraceItemTableRequest {
   PageToken page_token = 7;
 
   repeated VirtualColumnContext virtual_column_contexts = 8;
+
+  AggregationFilter aggregation_filter = 9;
+}
+
+message AggregationAndFilter {
+  repeated AggregationFilter filters = 1;
+}
+
+message AggregationOrFilter {
+  repeated AggregationFilter filters = 1;
+}
+
+message AggregationComparisonFilter {
+  enum Op {
+    OP_UNSPECIFIED = 0;
+    OP_LESS_THAN = 1;
+    OP_GREATER_THAN = 2;
+    OP_LESS_THAN_OR_EQUALS = 3;
+    OP_GREATER_THAN_OR_EQUALS = 4;
+    OP_EQUALS = 5;
+    OP_NOT_EQUALS = 6;
+  }
+  Function aggregate = 1;
+  AttributeKey key = 2;
+  Op op = 3;
+  AttributeValue value = 4;
+}
+
+message AggregationFilter {
+  oneof value {
+    AggregationAndFilter and_filter = 1;
+    AggregationOrFilter or_filter = 2;
+    AggregationComparisonFilter comparison_filter = 3;
+  }
 }
 
 message Column {

--- a/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
@@ -58,10 +58,9 @@ message AggregationComparisonFilter {
     OP_EQUALS = 5;
     OP_NOT_EQUALS = 6;
   }
-  Function aggregate = 1;
-  AttributeKey key = 2;
-  Op op = 3;
-  AttributeValue value = 4;
+  Column column = 1;
+  Op op = 2;
+  AttributeValue value = 3;
 }
 
 message AggregationFilter {

--- a/proto/sentry_protos/snuba/v1/trace_item_filter.proto
+++ b/proto/sentry_protos/snuba/v1/trace_item_filter.proto
@@ -35,22 +35,6 @@ message ComparisonFilter {
   AttributeValue value = 3;
 }
 
-message AggregationFilter {
-  enum Op {
-    OP_UNSPECIFIED = 0;
-    OP_LESS_THAN = 1;
-    OP_GREATER_THAN = 2;
-    OP_LESS_THAN_OR_EQUALS = 3;
-    OP_GREATER_THAN_OR_EQUALS = 4;
-    OP_EQUALS = 5;
-    OP_NOT_EQUALS = 6;
-  }
-  Function aggregate = 1;
-  AttributeKey key = 2;
-  Op op = 3;
-  AttributeValue value = 4;
-}
-
 message ExistsFilter {
   AttributeKey key = 1;
 }
@@ -70,6 +54,5 @@ message TraceItemFilter {
     NotFilter not_filter = 3;
     ComparisonFilter comparison_filter = 4;
     ExistsFilter exists_filter = 5;
-    AggregationFilter aggregation_filter = 6;
   }
 }

--- a/proto/sentry_protos/snuba/v1/trace_item_filter.proto
+++ b/proto/sentry_protos/snuba/v1/trace_item_filter.proto
@@ -35,6 +35,22 @@ message ComparisonFilter {
   AttributeValue value = 3;
 }
 
+message AggregationFilter {
+  enum Op {
+    OP_UNSPECIFIED = 0;
+    OP_LESS_THAN = 1;
+    OP_GREATER_THAN = 2;
+    OP_LESS_THAN_OR_EQUALS = 3;
+    OP_GREATER_THAN_OR_EQUALS = 4;
+    OP_EQUALS = 5;
+    OP_NOT_EQUALS = 6;
+  }
+  Function aggregate = 1;
+  AttributeKey key = 2;
+  Op op = 3;
+  AttributeValue value = 4;
+}
+
 message ExistsFilter {
   AttributeKey key = 1;
 }
@@ -54,5 +70,6 @@ message TraceItemFilter {
     NotFilter not_filter = 3;
     ComparisonFilter comparison_filter = 4;
     ExistsFilter exists_filter = 5;
+    AggregationFilter aggregation_filter = 6;
   }
 }

--- a/py/tests/test_snuba_v1.py
+++ b/py/tests/test_snuba_v1.py
@@ -313,7 +313,7 @@ def test_example_table_with_aggregation_filter() -> None:
         ],
         order_by=[TraceItemTableRequest.OrderBy(column=Column(label="duration_avg"))],
         aggregation_filter=AggregationFilter(
-            aggregation_comparison_filter=AggregationComparisonFilter(
+            comparison_filter=AggregationComparisonFilter(
                 column=Column(
                     aggregation=AttributeAggregation(
                         aggregate=Function.FUNCTION_COUNT,

--- a/py/tests/test_snuba_v1.py
+++ b/py/tests/test_snuba_v1.py
@@ -333,11 +333,11 @@ def test_example_table_with_aggregation_filter() -> None:
     TraceItemTableResponse(
         column_values=[
             TraceItemColumnValues(
-                attribute_name="span_name",
+                attribute_name="browser_name",
                 results=[AttributeValue(val_str="xyz"), AttributeValue(val_str="abc")],
             ),
             TraceItemColumnValues(
-                attribute_name="duration_p95",
+                attribute_name="duration_avg",
                 results=[AttributeValue(val_float=4.2), AttributeValue(val_float=6.9)],
             ),
         ],

--- a/py/tests/test_snuba_v1.py
+++ b/py/tests/test_snuba_v1.py
@@ -14,6 +14,8 @@ from sentry_protos.snuba.v1.endpoint_trace_item_attributes_pb2 import (
     TraceItemAttributeValuesResponse,
 )
 from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import (
+    AggregationComparisonFilter,
+    AggregationFilter,
     Column,
     TraceItemColumnValues,
     TraceItemTableRequest,
@@ -56,6 +58,7 @@ from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
     AttributeAggregation,
     AttributeKey,
     AttributeValue,
+    ExtrapolationMode,
     Function,
 )
 
@@ -287,6 +290,61 @@ def test_example_table_with_aggregations() -> None:
         ),  # if we're ordering by aggregate values, we can't paginate by anything except offset
     )
 
+def test_example_table_with_aggregation_filter() -> None:
+    TraceItemTableRequest(
+        meta=COMMON_META,
+        columns=[
+            Column(
+                key=AttributeKey(
+                    type=AttributeKey.TYPE_STRING, name="sentry.browser.name"
+                ),
+                label="browser_name",
+            ),
+            Column(
+                aggregation=AttributeAggregation(
+                    aggregate=Function.FUNCTION_AVG,
+                    key=AttributeKey(
+                        type=AttributeKey.TYPE_FLOAT, name="sentry.duration"
+                    ),
+                    extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_NONE,
+                ),
+                label="duration_avg",
+            ),
+        ],
+        order_by=[TraceItemTableRequest.OrderBy(column=Column(label="duration_avg"))],
+        aggregation_filter=AggregationFilter(
+            aggregation_comparison_filter=AggregationComparisonFilter(
+                column=Column(
+                    aggregation=AttributeAggregation(
+                        aggregate=Function.FUNCTION_COUNT,
+                        key=AttributeKey(
+                            type=AttributeKey.TYPE_FLOAT, name="sentry.duration"
+                        ),
+                        extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_SAMPLE_WEIGHTED,
+                    ),
+                ),
+                op=AggregationComparisonFilter.OP_GREATER_THAN,
+                value=AttributeValue(val_float=100),
+            ),
+        ),
+        limit=2,
+    )
+
+    TraceItemTableResponse(
+        column_values=[
+            TraceItemColumnValues(
+                attribute_name="span_name",
+                results=[AttributeValue(val_str="xyz"), AttributeValue(val_str="abc")],
+            ),
+            TraceItemColumnValues(
+                attribute_name="duration_p95",
+                results=[AttributeValue(val_float=4.2), AttributeValue(val_float=6.9)],
+            ),
+        ],
+        page_token=PageToken(
+            offset=2
+        ), 
+    )
 
 def test_example_find_traces() -> None:
     # Find traces that contain a span event with a `span_name` of "database_query"


### PR DESCRIPTION
Adding an aggregation filter to allow queries with a having clause in order to support https://github.com/getsentry/eap-planning/issues/143

# Example
A trace item table request with an aggregation filter could look something like this:
```
{
  "meta": {
  },
  "columns": [
    {
      "key": {
        "type": "TYPE_STRING",
        "name": "sentry.browser.name"
      },
      "label": "browser.name"
    },
    {
      "aggregation": {
        "aggregate": "FUNCTION_AVG",
        "key": {
          "type": "TYPE_FLOAT",
          "name": "sentry.duration"
        },
        "label": "avg(duration)",
        "extrapolation_mode": "EXTRAPOLATION_MODE_SAMPLE_WEIGHTED"
      },
      "label": "avg(duration)"
    }
  ],
  "order_by": [
    {
      "column": {
        "aggregation": {
          "aggregate": "FUNCTION_AVG",
          "key": {
            "type": "TYPE_FLOAT",
            "name": "sentry.duration"
          },
          "label": "avg(duration)",
          "extrapolation_mode": "EXTRAPOLATION_MODE_SAMPLE_WEIGHTED"
        }
      }
    }
  ],
  "aggregation_filter": {
    "comparison_filter": {
      "aggregate": "FUNCTION_COUNT",
      "key": {
        "type": "TYPE_FLOAT",
        "name": "sentry.duration"
      },
      "op": "OP_GREATER_THAN",
      "value": {
        "val_int": 100
      }
    }
  },
  "limit": 100
}
```