### PR TITLE
fix(eap-api): Use `doubles` instead of `floats`

### DIFF
--- a/proto/sentry_protos/snuba/v1/trace_item_attribute.proto
+++ b/proto/sentry_protos/snuba/v1/trace_item_attribute.proto
@@ -57,13 +57,14 @@ message AttributeValue {
   oneof value {
     bool val_bool = 1;
     string val_str = 2;
-    float val_float = 3;
+    float val_float = 3 [deprecated = true];
     int64 val_int = 4;
     // set to true if value is null
     bool val_null = 5;
     StrArray val_str_array = 6;
     IntArray val_int_array = 7;
     FloatArray val_float_array = 8;
+    double val_double = 9;
   }
 }
 


### PR DESCRIPTION
Python floats are 64 bits, and when we store them into [Protobuf floats (which are 32 bits)](https://protobuf.dev/programming-guides/proto3/#scalar), they get downcasted. This results in inaccuracy upon retrieval.

This is how I found out Python floats are indeed 64 bits.
<img width="1454" alt="Screenshot 2025-01-10 at 10 51 17 AM" src="https://github.com/user-attachments/assets/6a39d158-64d8-4b7f-8034-b86138ad471e" />
https://docs.python.org/3/library/sys.html#sys.float_info

log_base_2(max_exp) + mant_dig + 1 (for sign) = 10 + 53 + 1 = 64
- log_base_2(max_exp): number of digits used to represent the exponent field
- mant_dig: number of digits in significand or mantissa
- 1: sign bit