### PR TITLE
feat(eap): Add an is_null field for to AttributeValue

### DIFF
--- a/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
@@ -88,6 +88,10 @@ message TraceItemColumnValues {
 
   // reliability of the values based on confidence interval and sample size math
   repeated Reliability reliabilities = 3;
+
+  // true if the value is present, false if it is not
+  // this is used to distinguish between a value of 0 and a value that is not present (e.g. an aggregation over an empty set of rows)
+  repeated bool data_present = 4;
 }
 
 // this is a response from the TraceItemTable endpoint

--- a/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
@@ -88,10 +88,6 @@ message TraceItemColumnValues {
 
   // reliability of the values based on confidence interval and sample size math
   repeated Reliability reliabilities = 3;
-
-  // true if the value is present, false if it is not
-  // this is used to distinguish between a value of 0 and a value that is not present (e.g. an aggregation over an empty set of rows)
-  repeated bool data_present = 4;
 }
 
 // this is a response from the TraceItemTable endpoint

--- a/proto/sentry_protos/snuba/v1/trace_item_attribute.proto
+++ b/proto/sentry_protos/snuba/v1/trace_item_attribute.proto
@@ -75,6 +75,8 @@ message AttributeValue {
     FloatArray val_float_array = 8 [deprecated = true];
     double val_double = 9;
     DoubleArray val_double_array = 10;
+    // true if the value is null
+    bool is_null = 11;
   }
 }
 

--- a/proto/sentry_protos/snuba/v1/trace_item_attribute.proto
+++ b/proto/sentry_protos/snuba/v1/trace_item_attribute.proto
@@ -61,6 +61,8 @@ message DoubleArray {
 }
 
 message AttributeValue {
+  // true if the value is null
+  bool is_null = 11;
   oneof value {
     bool val_bool = 1;
     string val_str = 2;
@@ -75,8 +77,6 @@ message AttributeValue {
     FloatArray val_float_array = 8 [deprecated = true];
     double val_double = 9;
     DoubleArray val_double_array = 10;
-    // true if the value is null
-    bool is_null = 11;
   }
 }
 


### PR DESCRIPTION
This is used to distinguish between fields that are default values (e.g. 0 and empty string) and fields that are null (e.g. when aggregating over an empty set).

The two approaches I thought of were:
1. add an array to represent if the result is null for each column (first commit)
2. add a bool value to the AttributeValue to represent nullity (most recent commit)

Since the first approach would increase the message size, I prefer the second approach which doesn't affect the message size.