### PR TITLE
feat: formulas in timeseries and traceitemtable endpoints

### DIFF
--- a/proto/sentry_protos/snuba/v1/endpoint_time_series.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_time_series.proto
@@ -23,11 +23,11 @@ message TimeSeriesRequest {
   // ex: avg(span.duration) where span.environment = 'production'
   TraceItemFilter filter = 2;
 
-  // deprecated, please use selected_aggregations instead
+  // deprecated, please use expressions instead
   repeated AttributeAggregation aggregations = 3 [deprecated = true];
 
   // the actual aggregation to compute ex: avg(span.duration) or avg(span.duration) / sum(span.duration)
-  repeated SelectedAggregation selected_aggregations = 6;
+  repeated Expression expressions = 6;
 
   // the level of detail in the timeseries graph,
   // low granularity is very detailed, high is less detail.
@@ -43,8 +43,8 @@ message TimeSeriesRequest {
   repeated AttributeKey group_by = 5;
 }
 
-message SelectedAggregation {
-  oneof selected_aggregation {
+message Expression {
+  oneof expression {
     AttributeAggregation aggregation = 1;
     BinaryFormula formula = 2;
   }
@@ -58,8 +58,8 @@ message SelectedAggregation {
       OP_SUBTRACT = 4;
     }
     Op op = 1;
-    SelectedAggregation arg1 = 2;
-    SelectedAggregation arg2 = 3;
+    Expression left = 2;
+    Expression right = 3;
   }
 }
 

--- a/proto/sentry_protos/snuba/v1/endpoint_time_series.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_time_series.proto
@@ -23,8 +23,11 @@ message TimeSeriesRequest {
   // ex: avg(span.duration) where span.environment = 'production'
   TraceItemFilter filter = 2;
 
-  // the actual aggregation to compute ex: avg(span.duration)
-  repeated AttributeAggregation aggregations = 3;
+  // deprecated, please use selected_aggregations instead
+  repeated AttributeAggregation aggregations = 3 [deprecated = true];
+
+  // the actual aggregation to compute ex: avg(span.duration) or avg(span.duration) / sum(span.duration)
+  repeated SelectedAggregation selected_aggregations = 6;
 
   // the level of detail in the timeseries graph,
   // low granularity is very detailed, high is less detail.
@@ -38,6 +41,26 @@ message TimeSeriesRequest {
   // ex: span.environment might give 3 timeseries lines,
   //     one for prod, one for dev etc
   repeated AttributeKey group_by = 5;
+}
+
+message SelectedAggregation {
+  oneof selected_aggregation {
+    AttributeAggregation aggregation = 1;
+    BinaryFormula formula = 2;
+  }
+
+  message BinaryFormula {
+    enum Op {
+      OP_UNSPECIFIED = 0;
+      OP_DIVIDE = 1;
+      OP_MULTIPLY = 2;
+      OP_ADD = 3;
+      OP_SUBTRACT = 4;
+    }
+    Op op = 1;
+    SelectedAggregation arg1 = 2;
+    SelectedAggregation arg2 = 3;
+  }
 }
 
 message DataPoint {

--- a/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
@@ -90,8 +90,8 @@ message Column {
       OP_SUBTRACT = 4;
     }
     Op op = 1;
-    Column arg1 = 2;
-    Column arg2 = 3;
+    Column left = 2;
+    Column right = 3;
   }
 }
 

--- a/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
@@ -77,8 +77,22 @@ message Column {
   oneof column {
     AttributeKey key = 1;
     AttributeAggregation aggregation = 2;
+    BinaryFormula formula = 4;
   }
   string label = 3;
+
+  message BinaryFormula {
+    enum Op {
+      OP_UNSPECIFIED = 0;
+      OP_DIVIDE = 1;
+      OP_MULTIPLY = 2;
+      OP_ADD = 3;
+      OP_SUBTRACT = 4;
+    }
+    Op op = 1;
+    Column arg1 = 2;
+    Column arg2 = 3;
+  }
 }
 
 message TraceItemColumnValues {


### PR DESCRIPTION
Are we reimplementing snql? Who knows, but I am certainly reimplementing the grammar of a query language.

This allows `add`, `subtract`, `multiply`, and `divide` to be specified as operations in the "select" of timeseries endpoint and traceitemtable

The reason I nested `BinaryFormula` inside of `message Column` instead of making it separate is bc of the imports between timeseries and traceitemtable. It wouldnt let me name both messages `BinaryFormula` since it would be a duplicate object defined twice.