### PR TITLE
feat: Add a "trace item details" endpoint to get everything for a single item

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,7 +751,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.1.60"
+version = "0.1.61"
 dependencies = [
  "glob",
  "prost",

--- a/proto/sentry_protos/snuba/v1/endpoint_trace_item_details.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_trace_item_details.proto
@@ -26,7 +26,7 @@ message TraceItemDetailsAttribute {
 // this is a response from the TraceItemDetails endpoint
 message TraceItemDetailsResponse {
   string item_id = 1;
-  google.protobuf.Timestamp start_timestamp = 2;
+  google.protobuf.Timestamp timestamp = 2;
   repeated TraceItemDetailsAttribute attributes = 3;
   ResponseMeta meta = 4;
 }

--- a/proto/sentry_protos/snuba/v1/endpoint_trace_item_details.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_trace_item_details.proto
@@ -1,0 +1,29 @@
+syntax = "proto3";
+
+package sentry_protos.snuba.v1;
+
+import "sentry_protos/snuba/v1/request_common.proto";
+import "sentry_protos/snuba/v1/trace_item_attribute.proto";
+
+// This is a request to the TraceItemDetails endpoint,
+// it is used to query for TraceItems (ex. spans or logs)
+// it returns all of the information for a specific trace item.
+message TraceItemDetailsRequest {
+  RequestMeta meta = 1;
+
+  //required: the UUID of the item you are looking for
+  string item_uuid = 2;
+  //OPTIONAL: improves performance if included
+  string trace_id = 3;
+}
+
+message TraceItemDetailsAttribute {
+  string name = 1;
+  AttributeValue value = 2;
+}
+
+// this is a response from the TraceItemTable endpoint
+// it is the counterpart to TraceItemTableRequest
+message TraceItemDetailsResponse {
+  repeated TraceItemDetailsAttribute attributes = 1;
+}

--- a/proto/sentry_protos/snuba/v1/endpoint_trace_item_details.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_trace_item_details.proto
@@ -11,8 +11,8 @@ import "sentry_protos/snuba/v1/trace_item_attribute.proto";
 message TraceItemDetailsRequest {
   RequestMeta meta = 1;
 
-  //required: the UUID of the item you are looking for
-  string item_uuid = 2;
+  //required: the ID (hex string) of the item you are looking for
+  string item_id = 2;
   //OPTIONAL: improves performance if included
   string trace_id = 3;
 }

--- a/proto/sentry_protos/snuba/v1/endpoint_trace_item_details.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_trace_item_details.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package sentry_protos.snuba.v1;
 
+import "google/protobuf/timestamp.proto";
 import "sentry_protos/snuba/v1/request_common.proto";
 import "sentry_protos/snuba/v1/trace_item_attribute.proto";
 import "sentry_protos/snuba/v1/trace_item_filter.proto";
@@ -24,6 +25,8 @@ message TraceItemDetailsAttribute {
 
 // this is a response from the TraceItemDetails endpoint
 message TraceItemDetailsResponse {
-  repeated TraceItemDetailsAttribute attributes = 1;
-  ResponseMeta meta = 2;
+  string item_id = 1;
+  google.protobuf.Timestamp start_timestamp = 2;
+  repeated TraceItemDetailsAttribute attributes = 3;
+  ResponseMeta meta = 4;
 }

--- a/proto/sentry_protos/snuba/v1/endpoint_trace_item_details.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_trace_item_details.proto
@@ -4,6 +4,7 @@ package sentry_protos.snuba.v1;
 
 import "sentry_protos/snuba/v1/request_common.proto";
 import "sentry_protos/snuba/v1/trace_item_attribute.proto";
+import "sentry_protos/snuba/v1/trace_item_filter.proto";
 
 // This is a request to the TraceItemDetails endpoint,
 // it is used to query for TraceItems (ex. spans or logs)
@@ -13,8 +14,7 @@ message TraceItemDetailsRequest {
 
   //required: the ID (hex string) of the item you are looking for
   string item_id = 2;
-  //OPTIONAL: improves performance if included
-  string trace_id = 3;
+  TraceItemFilter filter = 3;
 }
 
 message TraceItemDetailsAttribute {
@@ -22,8 +22,8 @@ message TraceItemDetailsAttribute {
   AttributeValue value = 2;
 }
 
-// this is a response from the TraceItemTable endpoint
-// it is the counterpart to TraceItemTableRequest
+// this is a response from the TraceItemDetails endpoint
 message TraceItemDetailsResponse {
   repeated TraceItemDetailsAttribute attributes = 1;
+  ResponseMeta meta = 2;
 }

--- a/py/tests/test_snuba_v1.py
+++ b/py/tests/test_snuba_v1.py
@@ -392,7 +392,16 @@ def test_trace_item_details() -> None:
     TraceItemDetailsRequest(
         meta=COMMON_META,
         item_id='1234567812345678aabbccddeeff',
-        trace_id='41c1fcc9-6e12-44a9-bc83-2d9c949032fd',
+        filter=TraceItemFilter(
+            comparison_filter=ComparisonFilter(
+                key=AttributeKey(
+                    type=AttributeKey.TYPE_STRING,
+                    name="eap.measurement",
+                ),
+                op=ComparisonFilter.OP_LESS_THAN_OR_EQUALS,
+                value=AttributeValue(val_double=101),
+            )
+        )
     )
 
     TraceItemDetailsResponse(

--- a/py/tests/test_snuba_v1.py
+++ b/py/tests/test_snuba_v1.py
@@ -73,6 +73,12 @@ from sentry_protos.snuba.v1.endpoint_trace_item_stats_pb2 import (
     StatsType,
 )
 
+from sentry_protos.snuba.v1.endpoint_trace_item_details_pb2 import (
+    TraceItemDetailsRequest,
+    TraceItemDetailsAttribute,
+    TraceItemDetailsResponse,
+)
+
 COMMON_META = RequestMeta(
     project_ids=[1, 2, 3],
     organization_id=1,
@@ -379,6 +385,23 @@ def test_example_table_with_aggregation_filter() -> None:
         page_token=PageToken(
             offset=2
         ), 
+    )
+
+
+def text_trace_item_details() -> None:
+    TraceItemDetailsRequest(
+        meta=COMMON_META,
+        item_uuid='50a5923d-96bc-44ad-95fa-999530472b78',
+        trace_id='41c1fcc9-6e12-44a9-bc83-2d9c949032fd',
+    )
+
+    TraceItemTableResponse(
+        attributes=[
+            TraceItemDetailsAttribute(
+                name="sentry.db.operation",
+                value=AttributeValue(val_str="database_query")
+            )
+        ]
     )
 
 def test_example_find_traces() -> None:

--- a/py/tests/test_snuba_v1.py
+++ b/py/tests/test_snuba_v1.py
@@ -391,7 +391,7 @@ def test_example_table_with_aggregation_filter() -> None:
 def test_trace_item_details() -> None:
     TraceItemDetailsRequest(
         meta=COMMON_META,
-        item_uuid='50a5923d-96bc-44ad-95fa-999530472b78',
+        item_id='1234567812345678aabbccddeeff',
         trace_id='41c1fcc9-6e12-44a9-bc83-2d9c949032fd',
     )
 

--- a/py/tests/test_snuba_v1.py
+++ b/py/tests/test_snuba_v1.py
@@ -388,14 +388,14 @@ def test_example_table_with_aggregation_filter() -> None:
     )
 
 
-def text_trace_item_details() -> None:
+def test_trace_item_details() -> None:
     TraceItemDetailsRequest(
         meta=COMMON_META,
         item_uuid='50a5923d-96bc-44ad-95fa-999530472b78',
         trace_id='41c1fcc9-6e12-44a9-bc83-2d9c949032fd',
     )
 
-    TraceItemTableResponse(
+    TraceItemDetailsResponse(
         attributes=[
             TraceItemDetailsAttribute(
                 name="sentry.db.operation",


### PR DESCRIPTION
This lets you do the equivalent of `SELECT * FROM trace_items WHERE item_type=log AND item_id=12345`