### PR TITLE
feat(sampling-in-storage): api changes

### DIFF
--- a/proto/sentry_protos/snuba/v1/downsampled_storage.proto
+++ b/proto/sentry_protos/snuba/v1/downsampled_storage.proto
@@ -1,0 +1,26 @@
+syntax = "proto3";
+
+package sentry_protos.snuba.v1;
+
+message DownsampledStorageConfig {
+  enum Mode {
+    MODE_UNSPECIFIED = 0;
+    MODE_PREFLIGHT = 1;
+    MODE_BEST_EFFORT = 2;
+  }
+  Mode mode = 1;
+}
+
+message DownsampledStorageMeta {
+  enum SelectedTier {
+    SELECTED_TIER_UNSPECIFIED = 0;
+    SELECTED_TIER_1 = 1;
+    SELECTED_TIER_8 = 2;
+    SELECTED_TIER_64 = 3;
+    SELECTED_TIER_512 = 4;
+  }
+  SelectedTier tier = 1;
+  // how many rows did the estimator think this query would scan
+  // 0 means the estimator was not run
+  uint64 estimated_num_rows = 2;
+}

--- a/proto/sentry_protos/snuba/v1/request_common.proto
+++ b/proto/sentry_protos/snuba/v1/request_common.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package sentry_protos.snuba.v1;
 
 import "google/protobuf/timestamp.proto";
+import "sentry_protos/snuba/v1/downsampled_storage.proto";
 import "sentry_protos/snuba/v1/trace_item_filter.proto";
 
 message RequestMeta {
@@ -36,6 +37,9 @@ message RequestMeta {
 
   // a unique identifier for the request, user doesnt need to set this
   string request_id = 11;
+
+  // how to query the downsampled storages
+  DownsampledStorageConfig downsampled_storage_config = 12;
 }
 
 message ResponseMeta {
@@ -44,6 +48,9 @@ message ResponseMeta {
 
   // Optional field that is included only if debug is true
   repeated QueryInfo query_info = 2;
+
+  // metadata of how the query interacted wit the downsampled storages
+  DownsampledStorageMeta downsampled_storage_meta = 3;
 }
 
 // DEPRECATED: use TraceItemType instead


### PR DESCRIPTION
This PR enables users to specify the mode to interact with the downsampled storages and receive (as part of the request) metadata about the downsampled storages.

These API changes are necessary to address https://github.com/getsentry/eap-planning/issues/212 (for now, we are skipping over the additional mode (lower priority) where client (sentry) makes a request with its own rows scanned and timeout limit)