### PR TITLE
Make trace_id a first class field in TraceItemDetails

### DIFF
--- a/proto/sentry_protos/snuba/v1/endpoint_trace_item_details.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_trace_item_details.proto
@@ -15,6 +15,8 @@ message TraceItemDetailsRequest {
 
   //required: the ID (hex string) of the item you are looking for
   string item_id = 2;
+  // required: the trace ID of the item. 
+  string trace_id = 4;
   TraceItemFilter filter = 3;
 }
 


### PR DESCRIPTION
EAP is organized around traces and so it makes sense that to find a specific item, you would need a trace id as well. 

Practically, this makes it so that the indexing on `trace_id` is used for this lookup. Technically this can be facilitated through the optional `TraceItemFilter` that is on the message, however this makes it more clear to the user that `trace_id` is necessary for lookup