### PR TITLE
feat: default value for formulas

### DIFF
--- a/proto/sentry_protos/snuba/v1/endpoint_time_series.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_time_series.proto
@@ -65,7 +65,8 @@ message Expression {
     Op op = 1;
     Expression left = 2;
     Expression right = 3;
-    // optional, if the formula is invalid, use this value
+    // optional, if the formula evalutates to null this value is returned
+    // formula can evaluate to null if an attribute is missing for example
     oneof default_value {
       double default_value_double = 4;
       int64 default_value_int64 = 5;

--- a/proto/sentry_protos/snuba/v1/endpoint_time_series.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_time_series.proto
@@ -66,7 +66,10 @@ message Expression {
     Expression left = 2;
     Expression right = 3;
     // optional, if the formula is invalid, use this value
-    optional double default_value = 4;
+    oneof default_value {
+      double default_value_double = 4;
+      int64 default_value_int64 = 5;
+    }
   }
 }
 

--- a/proto/sentry_protos/snuba/v1/endpoint_time_series.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_time_series.proto
@@ -65,6 +65,8 @@ message Expression {
     Op op = 1;
     Expression left = 2;
     Expression right = 3;
+    // optional, if the formula is invalid, use this value
+    optional double default_value = 4;
   }
 }
 

--- a/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
@@ -97,6 +97,8 @@ message Column {
     Op op = 1;
     Column left = 2;
     Column right = 3;
+    // optional, if the formula is invalid, use this value
+    optional double default_value = 4;
   }
 }
 

--- a/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
@@ -97,7 +97,8 @@ message Column {
     Op op = 1;
     Column left = 2;
     Column right = 3;
-    // optional, if the formula is invalid, use this value
+    // optional, if the formula evalutates to null this value is returned
+    // formula can evaluate to null if an attribute is missing for example
     oneof default_value {
       double default_value_double = 4;
       int64 default_value_int64 = 5;

--- a/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
@@ -98,7 +98,10 @@ message Column {
     Column left = 2;
     Column right = 3;
     // optional, if the formula is invalid, use this value
-    optional double default_value = 4;
+    oneof default_value {
+      double default_value_double = 4;
+      int64 default_value_int64 = 5;
+    }
   }
 }
 

--- a/py/tests/test_snuba_v1.py
+++ b/py/tests/test_snuba_v1.py
@@ -130,6 +130,7 @@ def test_example_time_series():
                         ),
                         label="p90",
                     ),
+                    default_value_double=1.0,
                 ),
                 label="p50 / p90"
             ),


### PR DESCRIPTION
this allows user to specify default values for formulas in the traceitemtable and timeseries endpoints.

still needs support for it to be implemented in snuba.

it is for this ticket
https://github.com/orgs/getsentry/projects/284/views/1?pane=issue&itemId=104071496&issue=getsentry%7Ceap-planning%7C232