### PR TITLE
ref(eap): allow label for item table orderby

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -764,7 +764,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.1.75"
+version = "0.2.0"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
@@ -15,7 +15,10 @@ import "sentry_protos/snuba/v1/trace_item_filter.proto";
 // it can also be used for aggregations
 message TraceItemTableRequest {
   message OrderBy {
-    Column column = 1;
+    oneof orderby {
+      Column column = 1;
+      string label = 3;
+    }
     bool descending = 2;
   }
 

--- a/rust/src/sentry_protos.snuba.v1.rs
+++ b/rust/src/sentry_protos.snuba.v1.rs
@@ -1586,10 +1586,20 @@ pub struct TraceItemTableRequest {
 pub mod trace_item_table_request {
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct OrderBy {
-        #[prost(message, optional, tag = "1")]
-        pub column: ::core::option::Option<super::Column>,
         #[prost(bool, tag = "2")]
         pub descending: bool,
+        #[prost(oneof = "order_by::Orderby", tags = "1, 3")]
+        pub orderby: ::core::option::Option<order_by::Orderby>,
+    }
+    /// Nested message and enum types in `OrderBy`.
+    pub mod order_by {
+        #[derive(Clone, PartialEq, ::prost::Oneof)]
+        pub enum Orderby {
+            #[prost(message, tag = "1")]
+            Column(super::super::Column),
+            #[prost(string, tag = "3")]
+            Label(::prost::alloc::string::String),
+        }
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]


### PR DESCRIPTION
Addresses [EAP-90](https://linear.app/getsentry/issue/EAP-90/improve-order-by-in-protobuf-requests)

`OrderBy` can now additionally allow the order by to be the label directly instead of the full `Column` definition (which ultimately uses `column.label` for orderby)

