### PR TITLE
Clarify alternative to `FUNCTION_AVERAGE`

### DIFF
--- a/proto/sentry_protos/snuba/v1/trace_item_attribute.proto
+++ b/proto/sentry_protos/snuba/v1/trace_item_attribute.proto
@@ -83,6 +83,7 @@ message AttributeValue {
 enum Function {
   FUNCTION_UNSPECIFIED = 0;
   FUNCTION_SUM = 1;
+  // deprecated, use FUNCTION_AVG instead
   FUNCTION_AVERAGE = 2 [deprecated = true];
   FUNCTION_COUNT = 3;
   FUNCTION_P50 = 4;

--- a/rust/src/sentry_protos.snuba.v1.rs
+++ b/rust/src/sentry_protos.snuba.v1.rs
@@ -167,6 +167,7 @@ pub struct AttributeAggregation {
 pub enum Function {
     Unspecified = 0,
     Sum = 1,
+    /// deprecated, use FUNCTION_AVG instead
     Average = 2,
     Count = 3,
     P50 = 4,


### PR DESCRIPTION
Someone asked why this was deprecated / what the alternative was. Let's make it explicitly clear what to use instead