### PR TITLE
feat(eap): Allow to pass a different retention for downsampled data

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
-/proto/sentry_protos/snuba                       @getsentry/performance @getsentry/owners-snuba
+/proto/sentry_protos/snuba                       @getsentry/owners-snuba
 /proto/sentry_protos/taskbroker                  @getsentry/taskbroker

--- a/proto/sentry_protos/snuba/v1/trace_item.proto
+++ b/proto/sentry_protos/snuba/v1/trace_item.proto
@@ -46,4 +46,5 @@ message TraceItem {
   // Internal fields
   uint32 retention_days = 100;
   google.protobuf.Timestamp received = 101;
+  uint32 downsampled_retention_days = 102;
 }

--- a/rust/src/sentry_protos.snuba.v1.rs
+++ b/rust/src/sentry_protos.snuba.v1.rs
@@ -1914,4 +1914,6 @@ pub struct TraceItem {
     pub retention_days: u32,
     #[prost(message, optional, tag = "101")]
     pub received: ::core::option::Option<::prost_types::Timestamp>,
+    #[prost(uint32, tag = "102")]
+    pub downsampled_retention_days: u32,
 }


### PR DESCRIPTION
This PR allows us to pass a different value for retention of the downsampled datasets.