### PR TITLE
feat: heatmap support for traceitemstats endpoint

### DIFF
--- a/proto/sentry_protos/snuba/v1/endpoint_trace_item_stats.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_trace_item_stats.proto
@@ -11,9 +11,17 @@ message AttributeDistributionsRequest {
   uint32 max_attributes = 2;
 }
 
+message HeatmapRequest {
+  uint32 max_attribute_value_buckets = 1;
+  uint32 max_attributes = 2;
+  uint32 num_heatmap_buckets = 3;
+  string numerical_grouping_attribute_name = 4;
+}
+
 message StatsType {
   oneof type {
     AttributeDistributionsRequest attribute_distributions = 1;
+    HeatmapRequest heatmap = 2;
   }
 }
 
@@ -38,9 +46,30 @@ message AttributeDistributions {
   repeated AttributeDistribution attributes = 1;
 }
 
+message Heatmap {
+  repeated AttributeHeatmap attribute_heatmaps = 1;
+}
+
+message AttributeHeatmap {
+  message InnerBucket {
+    int32 range_start = 1;
+    int32 range_end = 2;
+    float value = 3;
+  }
+
+  message Bucket {
+    string label = 1;
+    repeated InnerBucket inner_buckets = 2;
+  }
+
+  string attribute_name = 1;
+  repeated Bucket buckets = 2;
+}
+
 message TraceItemStatsResult {
   oneof result {
     AttributeDistributions attribute_distributions = 1;
+    Heatmap heatmap = 2;
   }
 }
 

--- a/proto/sentry_protos/snuba/v1/endpoint_trace_item_stats.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_trace_item_stats.proto
@@ -47,7 +47,8 @@ message AttributeDistributions {
 }
 
 message Heatmap {
-  repeated AttributeHeatmap attribute_heatmaps = 1;
+  string numerical_grouping_attribute_name = 1;
+  repeated AttributeHeatmap attribute_heatmaps = 2;
 }
 
 message AttributeHeatmap {
@@ -58,7 +59,7 @@ message AttributeHeatmap {
   }
 
   message Bucket {
-    string label = 1;
+    string value = 1;
     repeated InnerBucket inner_buckets = 2;
   }
 

--- a/rust/src/sentry_protos.snuba.v1.rs
+++ b/rust/src/sentry_protos.snuba.v1.rs
@@ -1503,17 +1503,30 @@ pub struct AttributeDistributionsRequest {
     #[prost(uint32, tag = "2")]
     pub max_attributes: u32,
 }
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HeatmapRequest {
+    #[prost(uint32, tag = "1")]
+    pub max_attribute_value_buckets: u32,
+    #[prost(uint32, tag = "2")]
+    pub max_attributes: u32,
+    #[prost(uint32, tag = "3")]
+    pub num_heatmap_buckets: u32,
+    #[prost(string, tag = "4")]
+    pub numerical_grouping_attribute_name: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StatsType {
-    #[prost(oneof = "stats_type::Type", tags = "1")]
+    #[prost(oneof = "stats_type::Type", tags = "1, 2")]
     pub r#type: ::core::option::Option<stats_type::Type>,
 }
 /// Nested message and enum types in `StatsType`.
 pub mod stats_type {
-    #[derive(Clone, Copy, PartialEq, ::prost::Oneof)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Type {
         #[prost(message, tag = "1")]
         AttributeDistributions(super::AttributeDistributionsRequest),
+        #[prost(message, tag = "2")]
+        Heatmap(super::HeatmapRequest),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1549,8 +1562,41 @@ pub struct AttributeDistributions {
     pub attributes: ::prost::alloc::vec::Vec<AttributeDistribution>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Heatmap {
+    #[prost(string, tag = "1")]
+    pub numerical_grouping_attribute_name: ::prost::alloc::string::String,
+    #[prost(message, repeated, tag = "2")]
+    pub attribute_heatmaps: ::prost::alloc::vec::Vec<AttributeHeatmap>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AttributeHeatmap {
+    #[prost(string, tag = "1")]
+    pub attribute_name: ::prost::alloc::string::String,
+    #[prost(message, repeated, tag = "2")]
+    pub buckets: ::prost::alloc::vec::Vec<attribute_heatmap::Bucket>,
+}
+/// Nested message and enum types in `AttributeHeatmap`.
+pub mod attribute_heatmap {
+    #[derive(Clone, Copy, PartialEq, ::prost::Message)]
+    pub struct InnerBucket {
+        #[prost(int32, tag = "1")]
+        pub range_start: i32,
+        #[prost(int32, tag = "2")]
+        pub range_end: i32,
+        #[prost(float, tag = "3")]
+        pub value: f32,
+    }
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct Bucket {
+        #[prost(string, tag = "1")]
+        pub value: ::prost::alloc::string::String,
+        #[prost(message, repeated, tag = "2")]
+        pub inner_buckets: ::prost::alloc::vec::Vec<InnerBucket>,
+    }
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TraceItemStatsResult {
-    #[prost(oneof = "trace_item_stats_result::Result", tags = "1")]
+    #[prost(oneof = "trace_item_stats_result::Result", tags = "1, 2")]
     pub result: ::core::option::Option<trace_item_stats_result::Result>,
 }
 /// Nested message and enum types in `TraceItemStatsResult`.
@@ -1559,6 +1605,8 @@ pub mod trace_item_stats_result {
     pub enum Result {
         #[prost(message, tag = "1")]
         AttributeDistributions(super::AttributeDistributions),
+        #[prost(message, tag = "2")]
+        Heatmap(super::Heatmap),
     }
 }
 /// this is a response from the TraceItemStats endpoint


### PR DESCRIPTION
this is the interface definition for this https://linear.app/getsentry/issue/EAP-190/support-heat-map-representation-in-traceitemstats-endpoint

see here for example usage https://www.notion.so/sentry/example-request-and-response-2638b10e4b5d801f9ff8ebaaab9ff970

## design decisions for the endpoint
- bucket ranges for the numerical attribute will be the same across all attributes and values based on the global range
- the highest occurring attributes are the ones shown
- the highest occurring values within attributes are the ones shown