### PR TITLE
feat(cbrs): add time boundaries in response

### DIFF
--- a/proto/sentry_protos/snuba/v1/downsampled_storage.proto
+++ b/proto/sentry_protos/snuba/v1/downsampled_storage.proto
@@ -39,4 +39,11 @@ message DownsampledStorageMeta {
   // if there exists a higher accuracy tier that this query could route to
   // note that if this query goes to a higher accuracy tier, it could potentially time out
   bool can_go_to_higher_accuracy_tier = 3;
+
+  // This is for logs only, where we may truncate the start/end time of the query in order to meet the time deadline and in the PageToken, responds with the actual time boundaries
+  message PageToken {
+    int64 start_timestamp = 1;
+    int64 end_timestamp = 2;
+  }
+  optional PageToken page_token = 4;
 }

--- a/rust/src/sentry_protos.snuba.v1.rs
+++ b/rust/src/sentry_protos.snuba.v1.rs
@@ -501,9 +501,19 @@ pub struct DownsampledStorageMeta {
     /// note that if this query goes to a higher accuracy tier, it could potentially time out
     #[prost(bool, tag = "3")]
     pub can_go_to_higher_accuracy_tier: bool,
+    #[prost(message, optional, tag = "4")]
+    pub page_token: ::core::option::Option<downsampled_storage_meta::PageToken>,
 }
 /// Nested message and enum types in `DownsampledStorageMeta`.
 pub mod downsampled_storage_meta {
+    /// This is for logs only, where we may truncate the start/end time of the query in order to meet the time deadline and in the PageToken, responds with the actual time boundaries
+    #[derive(Clone, Copy, PartialEq, ::prost::Message)]
+    pub struct PageToken {
+        #[prost(int64, tag = "1")]
+        pub start_timestamp: i64,
+        #[prost(int64, tag = "2")]
+        pub end_timestamp: i64,
+    }
     #[derive(
         Clone,
         Copy,


### PR DESCRIPTION
https://www.notion.so/sentry/Logs-Query-Routing-2628b10e4b5d803b9bb4ef96af55725c?source=copy_link#2698b10e4b5d80aebb58d07ba2a40b77

With the HIGHEST_ACCURACY_FLEXTIME mode, we send these log queries to tier 1 but in order to meet the time deadline (30s), we truncate start/end time of log queries. So we have to inform the user how we truncated it