### PR TITLE
ref(tracemetrics): Add metric item type

### DIFF
--- a/proto/sentry_protos/snuba/v1/request_common.proto
+++ b/proto/sentry_protos/snuba/v1/request_common.proto
@@ -69,6 +69,7 @@ enum TraceItemType {
   TRACE_ITEM_TYPE_UPTIME_RESULT = 5;
   TRACE_ITEM_TYPE_REPLAY = 6;
   TRACE_ITEM_TYPE_OCCURRENCE = 7;
+  TRACE_ITEM_TYPE_METRIC = 8;
 }
 
 message TraceItemFilterWithType {

--- a/rust/src/sentry_protos.snuba.v1.rs
+++ b/rust/src/sentry_protos.snuba.v1.rs
@@ -740,6 +740,7 @@ pub enum TraceItemType {
     UptimeResult = 5,
     Replay = 6,
     Occurrence = 7,
+    Metric = 8,
 }
 impl TraceItemType {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -756,6 +757,7 @@ impl TraceItemType {
             TraceItemType::UptimeResult => "TRACE_ITEM_TYPE_UPTIME_RESULT",
             TraceItemType::Replay => "TRACE_ITEM_TYPE_REPLAY",
             TraceItemType::Occurrence => "TRACE_ITEM_TYPE_OCCURRENCE",
+            TraceItemType::Metric => "TRACE_ITEM_TYPE_METRIC",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -769,6 +771,7 @@ impl TraceItemType {
             "TRACE_ITEM_TYPE_UPTIME_RESULT" => Some(Self::UptimeResult),
             "TRACE_ITEM_TYPE_REPLAY" => Some(Self::Replay),
             "TRACE_ITEM_TYPE_OCCURRENCE" => Some(Self::Occurrence),
+            "TRACE_ITEM_TYPE_METRIC" => Some(Self::Metric),
             _ => None,
         }
     }


### PR DESCRIPTION
Adds a new TraceItemType for metrics as we are planning to store these in EAP.