### PR TITLE
ref: Add daily breakdown to usage pricer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.8.7"
+version = "0.8.9"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/services/usage_pricer/v1/endpoint_usage_pricer.proto
+++ b/proto/sentry_protos/billing/v1/services/usage_pricer/v1/endpoint_usage_pricer.proto
@@ -3,7 +3,10 @@ syntax = "proto3";
 package sentry_protos.billing.v1.services.usage_pricer.v1;
 
 import "google/protobuf/timestamp.proto";
+import "sentry_protos/billing/v1/date.proto";
 import "sentry_protos/billing/v1/sku.proto";
+import "sentry_protos/billing/v1/usage_data.proto";
+import "sentry_protos/billing/v1/data_category.proto";
 
 message UsagePricerRequest {
   uint64 organization_id = 1;
@@ -16,21 +19,36 @@ message SKUUsageSummary {
   // Net cents consumed by this SKU in the billing period (after credits/trials applied).
   uint64 payg_spend_cents = 2;
   // Total units consumed by this SKU in the billing period.
-  uint64 usage_volume = 3;
+  uint64 usage_volume = 3 [deprecated = true]; //DEPRECATED: use UsageData
+  sentry_protos.billing.v1.UsageData data = 4;
 }
 
 // Pricing breakdown for a shared budget spanning multiple SKUs.
 message SharedBudgetUsageSummary {
-  repeated sentry_protos.billing.v1.SKU skus = 1;
-  // Net cents consumed across all SKUs in this shared budget (after credits/trials applied).
-  uint64 payg_spend_cents = 2;
+  repeated sentry_protos.billing.v1.SKU skus = 1 [deprecated = true]; //DEPRECATED: use sku_summaries.sku
+  uint64 payg_spend_cents = 2 [deprecated = true]; //DEPRECATED: use sku_summaries.payg_spend_cents
   // Per-SKU breakdown within the shared budget.
   repeated SKUUsageSummary sku_summaries = 3;
 }
 
+// Weighted outcome breakdown for a single SKU on a single day.
+message SKUUsageData {
+  sentry_protos.billing.v1.SKU sku = 1;
+  repeated SharedBudgetUsageSummary summary = 2;
+}
+
+// All usage for a single day, with cumulative pricing up to that day.
+message DailyPricedUsage {
+  sentry_protos.billing.v1.Date date = 1;
+  // Per-SKU weighted outcome breakdown for this day (non-cumulative).
+  repeated SKUUsageData sku_usage = 2;
+}
+
 message UsagePricerResponse {
   // Per-SKU pricing breakdown.
-  repeated SKUUsageSummary sku_summaries = 1;
+  repeated SKUUsageSummary sku_summaries = 1 [deprecated = true]; //DEPRECATED: use daily
   // Per-shared-budget pricing breakdown (for SKUs sharing a budget).
-  repeated SharedBudgetUsageSummary shared_budget_summaries = 2;
+  repeated SharedBudgetUsageSummary shared_budget_summaries = 2 [deprecated = true]; //DEPRECATED: use daily
+  // Daily breakdown with per-day usage and cumulative pricing.
+  repeated DailyPricedUsage daily = 3;
 }

--- a/rust/src/sentry_protos.billing.v1.services.usage_pricer.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.usage_pricer.v1.rs
@@ -16,27 +16,66 @@ pub struct SkuUsageSummary {
     #[prost(uint64, tag = "2")]
     pub payg_spend_cents: u64,
     /// Total units consumed by this SKU in the billing period.
+    ///
+    /// DEPRECATED: use UsageData
+    #[deprecated]
     #[prost(uint64, tag = "3")]
     pub usage_volume: u64,
+    #[prost(message, optional, tag = "4")]
+    pub data: ::core::option::Option<super::super::super::UsageData>,
 }
 /// Pricing breakdown for a shared budget spanning multiple SKUs.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SharedBudgetUsageSummary {
-    #[prost(enumeration = "super::super::super::Sku", repeated, tag = "1")]
+    /// DEPRECATED: use sku_summaries.sku
+    #[deprecated]
+    #[prost(
+        enumeration = "super::super::super::Sku",
+        repeated,
+        packed = "false",
+        tag = "1"
+    )]
     pub skus: ::prost::alloc::vec::Vec<i32>,
-    /// Net cents consumed across all SKUs in this shared budget (after credits/trials applied).
+    /// DEPRECATED: use sku_summaries.payg_spend_cents
+    #[deprecated]
     #[prost(uint64, tag = "2")]
     pub payg_spend_cents: u64,
     /// Per-SKU breakdown within the shared budget.
     #[prost(message, repeated, tag = "3")]
     pub sku_summaries: ::prost::alloc::vec::Vec<SkuUsageSummary>,
 }
+/// Weighted outcome breakdown for a single SKU on a single day.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SkuUsageData {
+    #[prost(enumeration = "super::super::super::Sku", tag = "1")]
+    pub sku: i32,
+    #[prost(message, repeated, tag = "2")]
+    pub summary: ::prost::alloc::vec::Vec<SharedBudgetUsageSummary>,
+}
+/// All usage for a single day, with cumulative pricing up to that day.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DailyPricedUsage {
+    #[prost(message, optional, tag = "1")]
+    pub date: ::core::option::Option<super::super::super::Date>,
+    /// Per-SKU weighted outcome breakdown for this day (non-cumulative).
+    #[prost(message, repeated, tag = "2")]
+    pub sku_usage: ::prost::alloc::vec::Vec<SkuUsageData>,
+}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UsagePricerResponse {
     /// Per-SKU pricing breakdown.
+    ///
+    /// DEPRECATED: use daily
+    #[deprecated]
     #[prost(message, repeated, tag = "1")]
     pub sku_summaries: ::prost::alloc::vec::Vec<SkuUsageSummary>,
     /// Per-shared-budget pricing breakdown (for SKUs sharing a budget).
+    ///
+    /// DEPRECATED: use daily
+    #[deprecated]
     #[prost(message, repeated, tag = "2")]
     pub shared_budget_summaries: ::prost::alloc::vec::Vec<SharedBudgetUsageSummary>,
+    /// Daily breakdown with per-day usage and cumulative pricing.
+    #[prost(message, repeated, tag = "3")]
+    pub daily: ::prost::alloc::vec::Vec<DailyPricedUsage>,
 }


### PR DESCRIPTION
Three changes here:

1 - I think we need daily priced usage for the Usage & Billing Subscription page that shows a breakdown per day, or for the CSV export.
2 - Deprecated fields that are superseded by the daily version. Callers can just sum the daily version to get totals 
3 - deprecated usage_volume which was essentially only accepted, so that we can also include dropped etc