### PR TITLE
feat(taskbroker): Introduce parameters_bytes.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.8.11"
+version = "0.8.12"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/taskbroker/v1/taskbroker.proto
+++ b/proto/sentry_protos/taskbroker/v1/taskbroker.proto
@@ -49,8 +49,14 @@ message TaskActivation {
   // The name of the task. This name is resolved within the worker
   string taskname = 3;
 
-  // An opaque parameter collection. Could be JSON or protobuf encoded
-  string parameters = 4;
+  // DEPRECATED: Use parameters_bytes instead.
+  // An opaque JSON-encoded parameter string.
+  string parameters = 4 [deprecated = true];
+
+  // Msgpack-encoded parameter bytes containing {"args": [...], "kwargs": {...}}.
+  // May be zstd-compressed; check headers["compression-type"].
+  // Mutually exclusive with `parameters`.
+  bytes parameters_bytes = 13;
 
   // A map of headers for the task.
   map<string, string> headers = 5;

--- a/rust/src/sentry_protos.taskbroker.v1.rs
+++ b/rust/src/sentry_protos.taskbroker.v1.rs
@@ -31,9 +31,16 @@ pub struct TaskActivation {
     /// The name of the task. This name is resolved within the worker
     #[prost(string, tag = "3")]
     pub taskname: ::prost::alloc::string::String,
-    /// An opaque parameter collection. Could be JSON or protobuf encoded
+    /// DEPRECATED: Use parameters_bytes instead.
+    /// An opaque JSON-encoded parameter string.
+    #[deprecated]
     #[prost(string, tag = "4")]
     pub parameters: ::prost::alloc::string::String,
+    /// Msgpack-encoded parameter bytes containing {"args": \[...\], "kwargs": {...}}.
+    /// May be zstd-compressed; check headers\["compression-type"\].
+    /// Mutually exclusive with `parameters`.
+    #[prost(bytes = "vec", tag = "13")]
+    pub parameters_bytes: ::prost::alloc::vec::Vec<u8>,
     /// A map of headers for the task.
     #[prost(map = "string, string", tag = "5")]
     pub headers: ::std::collections::HashMap<


### PR DESCRIPTION
In order to enable later work on porting consumers to tasks, we need a
way to pass the raw message payload to a task, see https://www.notion.so/sentry/DACI-for-Taskbroker-passthrough-mode-How-to-get-the-bytes-through-33c8b10e4b5d8074aa86db17336d451d

So we need to make a change in the schema to allow the passing of bytes.
The new payload_bytes field will hold task parameters, but encoded as
msgpack, which allows for bytestrings.

ref STREAM-882
