### PR TITLE
fix(billing-platform): Replace reserved_rate with reserved_pricing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.8.13"
+version = "0.8.14"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/common/v1/pricing_tier.proto
+++ b/proto/sentry_protos/billing/v1/common/v1/pricing_tier.proto
@@ -11,3 +11,12 @@ message PricingTier {
 message TieredPricingRate {
   repeated PricingTier tiers = 1;
 }
+
+message FixedPricingTier {
+  int64 value = 1;
+  uint64 base_price_cents = 2;
+}
+
+message FixedTierList {
+  repeated FixedPricingTier tiers = 1;
+}

--- a/proto/sentry_protos/billing/v1/services/package/v1/package.proto
+++ b/proto/sentry_protos/billing/v1/services/package/v1/package.proto
@@ -22,8 +22,10 @@ message LineItemConfig {
   sentry_protos.billing.v1.common.v1.LineItemDetails line_item = 7;
 
   oneof reserved_pricing {
+    // Used to calculate spend against reserved_pool_cents for shared line items
     sentry_protos.billing.v1.common.v1.TieredPricingRate reserved_pricing_rate = 8;
-    sentry_protos.billing.v1.common.v1.FixedTierList reserved_tiers = 8;
+    // Used to determine prices for distinct reserved tiers (ie 100K errors is $X / month)
+    sentry_protos.billing.v1.common.v1.FixedTierList reserved_tiers = 9;
   }
 }
 

--- a/proto/sentry_protos/billing/v1/services/package/v1/package.proto
+++ b/proto/sentry_protos/billing/v1/services/package/v1/package.proto
@@ -10,6 +10,7 @@ message LineItemConfig {
   // Base price for the line item (upgraded reserved volumes or add-on activation fees)
   uint64 base_price_cents = 1;
   sentry_protos.billing.v1.common.v1.TieredPricingRate payg_rate = 3;
+  //DEPRECATED: use reserved_pricing instead
   sentry_protos.billing.v1.common.v1.TieredPricingRate reserved_rate = 4; // for reserved budget line items
 
   // how many of this lineitem are included in the package, the customer can reserve more on their contract
@@ -19,6 +20,11 @@ message LineItemConfig {
   }
 
   sentry_protos.billing.v1.common.v1.LineItemDetails line_item = 7;
+
+  oneof reserved_pricing {
+    sentry_protos.billing.v1.common.v1.TieredPricingRate reserved_pricing_rate = 8;
+    sentry_protos.billing.v1.common.v1.FixedTierList reserved_tiers = 8;
+  }
 }
 
 // Represents a budget included in a package that is collectively used by one or more line items,

--- a/rust/src/sentry_protos.billing.v1.common.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.common.v1.rs
@@ -216,3 +216,15 @@ pub struct TieredPricingRate {
     #[prost(message, repeated, tag = "1")]
     pub tiers: ::prost::alloc::vec::Vec<PricingTier>,
 }
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct FixedPricingTier {
+    #[prost(int64, tag = "1")]
+    pub value: i64,
+    #[prost(uint64, tag = "2")]
+    pub base_price_cents: u64,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FixedTierList {
+    #[prost(message, repeated, tag = "1")]
+    pub tiers: ::prost::alloc::vec::Vec<FixedPricingTier>,
+}

--- a/rust/src/sentry_protos.billing.v1.services.package.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.package.v1.rs
@@ -8,6 +8,8 @@ pub struct LineItemConfig {
     pub payg_rate: ::core::option::Option<
         super::super::super::common::v1::TieredPricingRate,
     >,
+    /// DEPRECATED: use reserved_pricing instead
+    ///
     /// for reserved budget line items
     #[prost(message, optional, tag = "4")]
     pub reserved_rate: ::core::option::Option<
@@ -22,6 +24,8 @@ pub struct LineItemConfig {
     pub included_reserved_units: ::core::option::Option<
         line_item_config::IncludedReservedUnits,
     >,
+    #[prost(oneof = "line_item_config::ReservedPricing", tags = "8, 9")]
+    pub reserved_pricing: ::core::option::Option<line_item_config::ReservedPricing>,
 }
 /// Nested message and enum types in `LineItemConfig`.
 pub mod line_item_config {
@@ -33,6 +37,15 @@ pub mod line_item_config {
         /// the type communicates whether the line item is unlimited or not, additionally reserved budget line items have a non-zero reserved_rate in addition to 0 reserved_units
         #[prost(uint64, tag = "6")]
         NumReservedUnits(u64),
+    }
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum ReservedPricing {
+        /// Used to calculate spend against reserved_pool_cents for shared line items
+        #[prost(message, tag = "8")]
+        ReservedPricingRate(super::super::super::super::common::v1::TieredPricingRate),
+        /// Used to determine prices for distinct reserved tiers (ie 100K errors is $X / month)
+        #[prost(message, tag = "9")]
+        ReservedTiers(super::super::super::super::common::v1::FixedTierList),
     }
 }
 /// Represents a budget included in a package that is collectively used by one or more line items,


### PR DESCRIPTION
`reserved_rate` originally covered two different concepts: package-specific reserved tiers (ex 50k errors, 100k errors, 1M errors, etc.) and a per-unit rate for shared pool line items (ex legacy Seer). Those cases accept different inputs, reserved volume versus usage respectively, so separating them into distinct fields makes their meaning explicit and makes it easier for downstream services to interpret them correctly.