### PR TITLE
feat(billing-platform): Update UsagePricer protos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.8.15"
+version = "0.8.17"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/services/usage_pricer/v1/endpoint_usage_pricer.proto
+++ b/proto/sentry_protos/billing/v1/services/usage_pricer/v1/endpoint_usage_pricer.proto
@@ -15,6 +15,7 @@ message GetPriceForContractRequest {
   uint64 contract_id = 1;
 }
 
+// DEPRECATED: use LineItemUsageSummary instead
 message SKUUsageSummary {
   sentry_protos.billing.v1.SKU sku = 1;
   // Net cents consumed by this SKU in the billing period (after credits/trials applied).
@@ -23,7 +24,7 @@ message SKUUsageSummary {
   uint64 usage_volume = 3;
 }
 
-// Pricing breakdown for a shared budget spanning multiple SKUs.
+// DEPRECATED: use SharedLineItemUsageSummary instead
 message SharedBudgetUsageSummary {
   repeated sentry_protos.billing.v1.SKU skus = 1;
   // Net cents consumed across all SKUs in this shared budget (after credits/trials applied).
@@ -32,9 +33,28 @@ message SharedBudgetUsageSummary {
   repeated SKUUsageSummary sku_summaries = 3;
 }
 
+message LineItemUsageSummary {
+  string line_item_uid = 1;
+  // Net cents consumed by this line item in the billing period (after credits/trials applied).
+  uint64 payg_spend_cents = 2;
+}
+
+message SharedLineItemUsageSummary {
+  // Net cents consumed across all SKUs in this shared budget (after credits/trials applied).
+  uint64 payg_spend_cents = 1;
+
+  // Line item breakdown within shared budget
+  repeated LineItemUsageSummary line_item_summaries = 2;
+}
+
 message UsagePricerResponse {
-  // Per-SKU pricing breakdown.
+  // DEPRECATED: use line_item_summaries
   repeated SKUUsageSummary sku_summaries = 1;
-  // Per-shared-budget pricing breakdown (for SKUs sharing a budget).
+
+  // DEPRECATED: use shared_line_item_summaries
   repeated SharedBudgetUsageSummary shared_budget_summaries = 2;
+
+  repeated LineItemUsageSummary line_item_summaries = 3;
+
+  repeated SharedLineItemUsageSummary shared_line_item_summaries = 4;
 }

--- a/proto/sentry_protos/billing/v1/services/usage_pricer/v1/endpoint_usage_pricer.proto
+++ b/proto/sentry_protos/billing/v1/services/usage_pricer/v1/endpoint_usage_pricer.proto
@@ -52,10 +52,10 @@ message SharedLineItemUsageSummary {
 }
 
 message UsagePricerResponse {
-  // DEPRECATED: use line_item_summaries
+  // use line_item_summaries
   repeated SKUUsageSummary sku_summaries = 1 [deprecated = true];
 
-  // DEPRECATED: use shared_line_item_summaries
+  // use shared_line_item_summaries
   repeated SharedBudgetUsageSummary shared_budget_summaries = 2 [deprecated = true];
 
   repeated LineItemUsageSummary line_item_summaries = 3;

--- a/proto/sentry_protos/billing/v1/services/usage_pricer/v1/endpoint_usage_pricer.proto
+++ b/proto/sentry_protos/billing/v1/services/usage_pricer/v1/endpoint_usage_pricer.proto
@@ -38,7 +38,9 @@ message SharedBudgetUsageSummary {
 }
 
 message LineItemUsageSummary {
+  // Refers to uid in sentry_protos.billing.v1.common.v1.LineItemDetails
   string line_item_uid = 1;
+
   // Net cents consumed by this line item in the billing period (after credits/trials applied).
   uint64 payg_spend_cents = 2;
 }

--- a/proto/sentry_protos/billing/v1/services/usage_pricer/v1/endpoint_usage_pricer.proto
+++ b/proto/sentry_protos/billing/v1/services/usage_pricer/v1/endpoint_usage_pricer.proto
@@ -15,8 +15,10 @@ message GetPriceForContractRequest {
   uint64 contract_id = 1;
 }
 
-// DEPRECATED: use LineItemUsageSummary instead
 message SKUUsageSummary {
+  // use LineItemUsageSummary instead
+  option deprecated = true;
+
   sentry_protos.billing.v1.SKU sku = 1;
   // Net cents consumed by this SKU in the billing period (after credits/trials applied).
   uint64 payg_spend_cents = 2;
@@ -24,8 +26,10 @@ message SKUUsageSummary {
   uint64 usage_volume = 3;
 }
 
-// DEPRECATED: use SharedLineItemUsageSummary instead
 message SharedBudgetUsageSummary {
+  // use SharedLineItemUsageSummary instead
+  option deprecated = true;
+
   repeated sentry_protos.billing.v1.SKU skus = 1;
   // Net cents consumed across all SKUs in this shared budget (after credits/trials applied).
   uint64 payg_spend_cents = 2;
@@ -49,10 +53,10 @@ message SharedLineItemUsageSummary {
 
 message UsagePricerResponse {
   // DEPRECATED: use line_item_summaries
-  repeated SKUUsageSummary sku_summaries = 1;
+  repeated SKUUsageSummary sku_summaries = 1 [deprecated = true];
 
   // DEPRECATED: use shared_line_item_summaries
-  repeated SharedBudgetUsageSummary shared_budget_summaries = 2;
+  repeated SharedBudgetUsageSummary shared_budget_summaries = 2 [deprecated = true];
 
   repeated LineItemUsageSummary line_item_summaries = 3;
 

--- a/rust/src/sentry_protos.billing.v1.services.usage_pricer.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.usage_pricer.v1.rs
@@ -13,6 +13,7 @@ pub struct GetPriceForContractRequest {
     #[prost(uint64, tag = "1")]
     pub contract_id: u64,
 }
+/// DEPRECATED: use LineItemUsageSummary instead
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct SkuUsageSummary {
     #[prost(enumeration = "super::super::super::Sku", tag = "1")]
@@ -24,7 +25,7 @@ pub struct SkuUsageSummary {
     #[prost(uint64, tag = "3")]
     pub usage_volume: u64,
 }
-/// Pricing breakdown for a shared budget spanning multiple SKUs.
+/// DEPRECATED: use SharedLineItemUsageSummary instead
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SharedBudgetUsageSummary {
     #[prost(enumeration = "super::super::super::Sku", repeated, tag = "1")]
@@ -36,12 +37,33 @@ pub struct SharedBudgetUsageSummary {
     #[prost(message, repeated, tag = "3")]
     pub sku_summaries: ::prost::alloc::vec::Vec<SkuUsageSummary>,
 }
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct LineItemUsageSummary {
+    #[prost(string, tag = "1")]
+    pub line_item_uid: ::prost::alloc::string::String,
+    /// Net cents consumed by this line item in the billing period (after credits/trials applied).
+    #[prost(uint64, tag = "2")]
+    pub payg_spend_cents: u64,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SharedLineItemUsageSummary {
+    /// Net cents consumed across all SKUs in this shared budget (after credits/trials applied).
+    #[prost(uint64, tag = "1")]
+    pub payg_spend_cents: u64,
+    /// Line item breakdown within shared budget
+    #[prost(message, repeated, tag = "2")]
+    pub line_item_summaries: ::prost::alloc::vec::Vec<LineItemUsageSummary>,
+}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UsagePricerResponse {
-    /// Per-SKU pricing breakdown.
+    /// DEPRECATED: use line_item_summaries
     #[prost(message, repeated, tag = "1")]
     pub sku_summaries: ::prost::alloc::vec::Vec<SkuUsageSummary>,
-    /// Per-shared-budget pricing breakdown (for SKUs sharing a budget).
+    /// DEPRECATED: use shared_line_item_summaries
     #[prost(message, repeated, tag = "2")]
     pub shared_budget_summaries: ::prost::alloc::vec::Vec<SharedBudgetUsageSummary>,
+    #[prost(message, repeated, tag = "3")]
+    pub line_item_summaries: ::prost::alloc::vec::Vec<LineItemUsageSummary>,
+    #[prost(message, repeated, tag = "4")]
+    pub shared_line_item_summaries: ::prost::alloc::vec::Vec<SharedLineItemUsageSummary>,
 }

--- a/rust/src/sentry_protos.billing.v1.services.usage_pricer.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.usage_pricer.v1.rs
@@ -37,6 +37,7 @@ pub struct SharedBudgetUsageSummary {
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct LineItemUsageSummary {
+    /// Refers to uid in sentry_protos.billing.v1.common.v1.LineItemDetails
     #[prost(string, tag = "1")]
     pub line_item_uid: ::prost::alloc::string::String,
     /// Net cents consumed by this line item in the billing period (after credits/trials applied).

--- a/rust/src/sentry_protos.billing.v1.services.usage_pricer.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.usage_pricer.v1.rs
@@ -13,7 +13,6 @@ pub struct GetPriceForContractRequest {
     #[prost(uint64, tag = "1")]
     pub contract_id: u64,
 }
-/// DEPRECATED: use LineItemUsageSummary instead
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct SkuUsageSummary {
     #[prost(enumeration = "super::super::super::Sku", tag = "1")]
@@ -25,7 +24,6 @@ pub struct SkuUsageSummary {
     #[prost(uint64, tag = "3")]
     pub usage_volume: u64,
 }
-/// DEPRECATED: use SharedLineItemUsageSummary instead
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SharedBudgetUsageSummary {
     #[prost(enumeration = "super::super::super::Sku", repeated, tag = "1")]
@@ -56,10 +54,12 @@ pub struct SharedLineItemUsageSummary {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UsagePricerResponse {
-    /// DEPRECATED: use line_item_summaries
+    /// use line_item_summaries
+    #[deprecated]
     #[prost(message, repeated, tag = "1")]
     pub sku_summaries: ::prost::alloc::vec::Vec<SkuUsageSummary>,
-    /// DEPRECATED: use shared_line_item_summaries
+    /// use shared_line_item_summaries
+    #[deprecated]
     #[prost(message, repeated, tag = "2")]
     pub shared_budget_summaries: ::prost::alloc::vec::Vec<SharedBudgetUsageSummary>,
     #[prost(message, repeated, tag = "3")]


### PR DESCRIPTION
closes https://linear.app/getsentry/issue/REVENG-13/redefine-usagepricer-output-proto

Updates UsagePricer to use line items instead of SKUs