### PR TITLE
ref: Convert GetUninvoicedContractsResponse to return contract_ids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.8.15"
+version = "0.8.17"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_get_uninvoiced_contracts.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_get_uninvoiced_contracts.proto
@@ -19,9 +19,9 @@ message GetUninvoicedContractsRequest {
 }
 
 message GetUninvoicedContractsResponse {
-  repeated Contract contracts = 1;
-
+  repeated Contract contracts = 1 [deprecated = true]; //DEPRECATED: use contract_ids instead
   // True if additional matching contracts existed beyond max_items and were
   // not included in this response.
   bool truncated = 2;
+  repeated uint64 contract_ids = 3;
 }

--- a/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
@@ -453,12 +453,16 @@ pub struct GetUninvoicedContractsRequest {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetUninvoicedContractsResponse {
+    /// DEPRECATED: use contract_ids instead
+    #[deprecated]
     #[prost(message, repeated, tag = "1")]
     pub contracts: ::prost::alloc::vec::Vec<Contract>,
     /// True if additional matching contracts existed beyond max_items and were
     /// not included in this response.
     #[prost(bool, tag = "2")]
     pub truncated: bool,
+    #[prost(uint64, repeated, tag = "3")]
+    pub contract_ids: ::prost::alloc::vec::Vec<u64>,
 }
 /// Creates a new contract for a new billing period. Closes out the current contract by
 /// creating an invoice and setting the last usage date


### PR DESCRIPTION
When working on the implementation of this I realized the caller will only need the contract ids because these will be the input to taskworker jobs that run for each contract. The job will then use the id to request the full contract from the contract service.