### PR TITLE
feat(taskbroker): add TaskError to SetTaskStatusRequest

### DIFF
--- a/proto/sentry_protos/taskbroker/v1/taskbroker.proto
+++ b/proto/sentry_protos/taskbroker/v1/taskbroker.proto
@@ -117,6 +117,16 @@ message FetchNextTask {
   optional string application = 2;
 }
 
+message TaskError {
+  // Fully qualified exception class, e.g. "django.db.utils.OperationalError".
+  string exception_type = 1;
+  // str(exc), worker-truncated to a bounded character count (~2000 chars).
+  string exception_message = 2;
+  // Formatted traceback (tail), worker-truncated to a bounded character count
+  // (~8000 chars).
+  optional string traceback = 3;
+}
+
 message SetTaskStatusRequest {
   string id = 1;
 
@@ -124,6 +134,13 @@ message SetTaskStatusRequest {
 
   // If fetch_next is provided, receive a new task in the response
   optional FetchNextTask fetch_next_task = 3;
+
+  // Populated when the worker caught an exception while executing the task.
+  // Typically set with status == TASK_ACTIVATION_STATUS_FAILURE, and may be set
+  // with TASK_ACTIVATION_STATUS_RETRY when the retry was triggered by a caught
+  // exception (rather than by an explicit retry_task() call with no context).
+  // Used by the broker only for structured logging; not persisted.
+  optional TaskError error = 4;
 }
 
 message SetTaskStatusResponse {

--- a/rust/src/sentry_protos.taskbroker.v1.rs
+++ b/rust/src/sentry_protos.taskbroker.v1.rs
@@ -98,6 +98,19 @@ pub struct FetchNextTask {
     pub application: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct TaskError {
+    /// Fully qualified exception class, e.g. "django.db.utils.OperationalError".
+    #[prost(string, tag = "1")]
+    pub exception_type: ::prost::alloc::string::String,
+    /// str(exc), worker-truncated to a bounded character count (~2000 chars).
+    #[prost(string, tag = "2")]
+    pub exception_message: ::prost::alloc::string::String,
+    /// Formatted traceback (tail), worker-truncated to a bounded character count
+    /// (~8000 chars).
+    #[prost(string, optional, tag = "3")]
+    pub traceback: ::core::option::Option<::prost::alloc::string::String>,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct SetTaskStatusRequest {
     #[prost(string, tag = "1")]
     pub id: ::prost::alloc::string::String,
@@ -106,6 +119,13 @@ pub struct SetTaskStatusRequest {
     /// If fetch_next is provided, receive a new task in the response
     #[prost(message, optional, tag = "3")]
     pub fetch_next_task: ::core::option::Option<FetchNextTask>,
+    /// Populated when the worker caught an exception while executing the task.
+    /// Typically set with status == TASK_ACTIVATION_STATUS_FAILURE, and may be set
+    /// with TASK_ACTIVATION_STATUS_RETRY when the retry was triggered by a caught
+    /// exception (rather than by an explicit retry_task() call with no context).
+    /// Used by the broker only for structured logging; not persisted.
+    #[prost(message, optional, tag = "4")]
+    pub error: ::core::option::Option<TaskError>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SetTaskStatusResponse {


### PR DESCRIPTION
## Summary

Add a bounded `TaskError` envelope to the taskbroker status update contract.

This extends `SetTaskStatusRequest` with an optional `error` field so workers can attach exception context when reporting task failures/retries.

## Downstream PRs

Consumed by:
- getsentry/taskbroker#607
- getsentry/sentry#114009

## Changes

- add `TaskError` message:
  - `exception_type`
  - `exception_message`
  - `traceback`
- add optional `error` field to `SetTaskStatusRequest`

## Why

This is the wire-format foundation for end-to-end failure observability across:

- taskworker
- taskbroker
- Sentry

Without this, taskbroker cannot log worker-observed exception details.

## Compatibility

- field is additive
- old workers can continue sending requests without `error`
- new brokers must tolerate `error` being absent

## Validation

- updated `taskbroker.proto`
- regenerated Rust bindings
- verified that:
  - `TaskError` is generated with the expected fields
  - `SetTaskStatusRequest` includes optional `error = 4`
  - existing field numbers remain unchanged

## Follow-up

This is consumed by downstream changes in:

- `getsentry/taskbroker`
- `getsentry/sentry`