### PR TITLE
ref: Update contract protos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.8.17"
+version = "0.8.19"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/services/contract/v1/billing_config.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/billing_config.proto
@@ -18,6 +18,8 @@ enum BillingType {
 
 // The channel through which the contract is billed.
 enum BillingChannel {
+  option deprecated = true;
+
   BILLING_CHANNEL_UNSPECIFIED = 0;
   BILLING_CHANNEL_SELF_SERVE = 1;
   BILLING_CHANNEL_SALES = 2;
@@ -26,6 +28,8 @@ enum BillingChannel {
 
 // The external billing provider used to process payments for the contract.
 enum ExternalBillingProvider {
+  option deprecated = true;
+
   EXTERNAL_BILLING_PROVIDER_UNSPECIFIED = 0;
   EXTERNAL_BILLING_PROVIDER_STRIPE = 1;
   EXTERNAL_BILLING_PROVIDER_VERCEL = 2;
@@ -45,11 +49,12 @@ message Address {
 
 message BillingConfig {
   BillingType billing_type = 1;
-  BillingChannel channel = 2;
-  ExternalBillingProvider external_billing_provider = 3;
-  Address address = 4 [deprecated=true];
 
-  // Determines when to charge for base package price / subscription fee.
-  Date contract_start_date = 5;
-  Date contract_end_date = 6;
+  // Remaining fields are deprecated
+  BillingChannel channel = 2 [deprecated=true];
+  ExternalBillingProvider external_billing_provider = 3 [deprecated=true];
+  Address address = 4 [deprecated=true];
+  // Use PricingConfig.billing_period_start_date and PricingConfig.billing_period_end_date
+  Date contract_start_date = 5 [deprecated = true];
+  Date contract_end_date = 6 [deprecated = true];
 }

--- a/proto/sentry_protos/billing/v1/services/contract/v1/contract_metadata.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/contract_metadata.proto
@@ -13,11 +13,15 @@ message OptionValue {
 }
 
 message FeatureOption {
+  option deprecated = true;
+
   string key = 1;
   bool enabled = 2;
 }
 
 message FeatureOptions {
+  option deprecated = true;
+
   repeated FeatureOption options = 1;
 }
 
@@ -35,11 +39,13 @@ message ContractMetadata {
   uint64 organization_id = 2;
   // The set of BillingRules that the BillingRulesEngine has to execute for this contract.
   string ruleset_version = 3;
-  // Includes information like plan ID, tier, etc.
-  MetadataOptions package_metadata = 4;
-  // Entitlements, used in frontend features or gating access to certain features.
-  FeatureOptions features = 5 [deprecated = true]; //DEPRECATED: use billing_features instead
   // Catch-all for overrides and information not covered above.
   MetadataOptions custom_options = 6;
   sentry_protos.billing.v1.FeatureOptions billing_features = 7;
+  uint64 package_id = 8;
+
+  // Includes information like plan ID, tier, etc.
+  MetadataOptions package_metadata = 4 [deprecated = true];
+  // Entitlements, used in frontend features or gating access to certain features.
+  FeatureOptions features = 5 [deprecated = true]; //DEPRECATED: use billing_features instead
 }

--- a/proto/sentry_protos/billing/v1/services/contract/v1/pricing_config.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/pricing_config.proto
@@ -2,21 +2,29 @@ syntax = "proto3";
 
 package sentry_protos.billing.v1.services.contract.v1;
 
+import "google/protobuf/empty.proto";
+import "google/protobuf/timestamp.proto";
 import "sentry_protos/billing/v1/services/contract/v1/billing_config.proto";
 import "sentry_protos/billing/v1/services/contract/v1/sku.proto";
 import "sentry_protos/billing/v1/sku.proto";
 
 message PricingTier {
+  option deprecated = true;
+
   int64 start = 1;
   int64 end = 2;
   int64 rate_per_unit_cpe = 3;
 }
 
 message TieredPricingRate {
+  option deprecated = true;
+
   repeated PricingTier tiers = 1;
 }
 
 message SKUConfig {
+  option deprecated = true;
+
   SKU sku = 1 [deprecated = true]; //DEPRECATED: use billing_sku instead
   // Base price for the SKU (upgraded reserved volumes or add-on activation fees)
   uint64 base_price_cents = 2;
@@ -36,24 +44,53 @@ message SKUConfig {
 // Represents a budget that is collectively used by one or more SKUs,
 // allowing multiple SKUs to draw from the same reserved budget.
 message SharedSKUBudget {
+  option deprecated = true;
+
   repeated SKU skus = 1 [deprecated = true]; //DEPRECATED: use billing_skus instead
   uint64 reserved_budget_cents = 2;
   uint64 payg_budget_cents = 3;
   repeated sentry_protos.billing.v1.SKU billing_skus = 4;
 }
 
+message PAYGBudget {
+  uint64 budget_cents = 1;
+}
+
+message Reservation {
+  uint64 reserved_price_cents = 1;
+  oneof reserved_units {
+    bool is_unlimited = 2;
+    uint64 num_reserved_units = 3;
+  }
+}
+
+message LineItemUids {
+  repeated string uids = 1;
+}
+
+message UserConfig {
+  PAYGBudget payg_budget = 1;
+  Reservation reservation = 2;
+  oneof line_items {
+    LineItemUids specific_items = 3;
+    google.protobuf.Empty all_items = 4;
+  }
+}
+
 message PricingConfig {
-  repeated SKUConfig sku_configs = 1;
-  repeated SharedSKUBudget shared_sku_budgets = 2;
-  // Determines when to reset quotas and create an invoice.
+  // Determines when to reset quotas and charge the subscription price.
   Date billing_period_start_date = 3;
   Date billing_period_end_date = 4;
-
-  uint64 max_spend_cents = 5;
-  // Base price for the package.
-  uint64 base_price_cents = 6;
 
   //Determines when the on demand period for invoicing the organization starts and ends, even for annual plans we bill ondemand monthly
   Date ondemand_period_start_date = 7;
   Date ondemand_period_end_date = 8;
+  optional google.protobuf.Timestamp usage_watermark_ts = 9;
+
+  repeated UserConfig user_config = 10;
+
+  uint64 base_price_cents = 6 [deprecated = true]; // DEPRECATED: use package instead.
+  repeated SKUConfig sku_configs = 1 [deprecated = true]; // DEPRECATED: use package/user_parameters instead.
+  repeated SharedSKUBudget shared_sku_budgets = 2 [deprecated = true]; // DEPRECATED: use package/user_parameters instead.
+  uint64 max_spend_cents = 5 [deprecated = true]; // DEPRECATED: use user_parameters instead
 }

--- a/py/tests/test_billing_v1.py
+++ b/py/tests/test_billing_v1.py
@@ -19,12 +19,19 @@ from sentry_protos.billing.v1.services.contract.v1.endpoint_get_contract_pb2 imp
     GetContractResponse,
 )
 from sentry_protos.billing.v1.services.contract.v1.pricing_config_pb2 import (
+    LineItemUids,
+    PAYGBudget,
     PricingConfig,
     PricingTier,
+    Reservation,
     SharedSKUBudget,
     SKUConfig,
     TieredPricingRate,
+    UserConfig,
 )
+from sentry_protos.billing.v1 import feature_pb2 as billing_feature_pb2
+from google.protobuf.empty_pb2 import Empty
+from google.protobuf.timestamp_pb2 import Timestamp
 from sentry_protos.billing.v1.sku_pb2 import SKU
 from sentry_protos.billing.v1.credit_pb2 import (
     Credit,
@@ -399,3 +406,104 @@ def test_get_package_response():
     assert response.package_config.uid == "pkg_monthly_123"
     assert response.package_config.base_price_cents == 10000
     assert response.package_config.billing_interval == BillingInterval.BILLING_INTERVAL_MONTHLY
+
+
+def test_create_contract():
+    user_configs = [
+        UserConfig(
+            specific_items=LineItemUids(uids=["errors", "spans"]),
+            payg_budget=PAYGBudget(budget_cents=10_000),
+            reservation=Reservation(
+                reserved_price_cents=2900,
+                num_reserved_units=100_000,
+            ),
+        ),
+        UserConfig(
+            specific_items=LineItemUids(uids=["replays"]),
+            payg_budget=PAYGBudget(budget_cents=5_000),
+            reservation=Reservation(
+                reserved_price_cents=0,
+                is_unlimited=True,
+            ),
+        ),
+        UserConfig(
+            all_items=Empty(),
+            payg_budget=PAYGBudget(budget_cents=2_500),
+        ),
+    ]
+
+    contract = Contract(
+        metadata=ContractMetadata(
+            id=12345,
+            organization_id=67890,
+            ruleset_version="1",
+            package_id=42,
+            billing_features=billing_feature_pb2.FeatureOptions(
+                options=[
+                    billing_feature_pb2.FeatureOption(key="sso", enabled=True),
+                    billing_feature_pb2.FeatureOption(
+                        key="custom_dashboards", enabled=True
+                    ),
+                ],
+                start_date=BillingDate(year=2026, month=1, day=1),
+                end_date=BillingDate(year=2027, month=1, day=1),
+            ),
+            custom_options=MetadataOptions(
+                options=[
+                    MetadataOption(
+                        key="override_rate_limit",
+                        value=OptionValue(int_value=5000),
+                    ),
+                    MetadataOption(
+                        key="is_internal", value=OptionValue(bool_value=True)
+                    ),
+                ],
+            ),
+        ),
+        billing_config=BillingConfig(
+            billing_type=BillingType.BILLING_TYPE_INVOICED,
+        ),
+        pricing_config=PricingConfig(
+            billing_period_start_date=Date(year=2026, month=1, day=1),
+            billing_period_end_date=Date(year=2027, month=1, day=1),
+            ondemand_period_start_date=Date(year=2026, month=4, day=1),
+            ondemand_period_end_date=Date(year=2026, month=5, day=1),
+            usage_watermark_ts=Timestamp(seconds=1_714_000_000),
+            user_config=user_configs,
+        ),
+    )
+
+    assert contract.metadata.package_id == 42
+    assert contract.metadata.id == 12345
+    assert contract.metadata.organization_id == 67890
+
+    feature_map = {
+        f.key: f.enabled for f in contract.metadata.billing_features.options
+    }
+    assert feature_map == {"sso": True, "custom_dashboards": True}
+    assert contract.metadata.billing_features.start_date.year == 2026
+
+    custom_options = {
+        opt.key: opt.value for opt in contract.metadata.custom_options.options
+    }
+    assert custom_options["override_rate_limit"].int_value == 5000
+    assert custom_options["is_internal"].bool_value is True
+
+    assert contract.billing_config.billing_type == BillingType.BILLING_TYPE_INVOICED
+
+    pricing = contract.pricing_config
+    assert pricing.billing_period_start_date.year == 2026
+    assert pricing.billing_period_end_date.year == 2027
+    assert pricing.ondemand_period_start_date.month == 4
+    assert pricing.ondemand_period_end_date.month == 5
+    assert pricing.HasField("usage_watermark_ts")
+    assert pricing.usage_watermark_ts.seconds == 1_714_000_000
+
+    assert len(pricing.user_config) == 3
+    assert pricing.user_config[0].WhichOneof("line_items") == "specific_items"
+    assert list(pricing.user_config[0].specific_items.uids) == ["errors", "spans"]
+    assert pricing.user_config[0].payg_budget.budget_cents == 10_000
+    assert pricing.user_config[0].reservation.num_reserved_units == 100_000
+    assert pricing.user_config[1].reservation.is_unlimited is True
+    assert pricing.user_config[2].WhichOneof("line_items") == "all_items"
+    assert pricing.user_config[2].HasField("all_items")

--- a/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
@@ -29,16 +29,21 @@ pub struct Address {
 pub struct BillingConfig {
     #[prost(enumeration = "BillingType", tag = "1")]
     pub billing_type: i32,
+    /// Remaining fields are deprecated
+    #[deprecated]
     #[prost(enumeration = "BillingChannel", tag = "2")]
     pub channel: i32,
+    #[deprecated]
     #[prost(enumeration = "ExternalBillingProvider", tag = "3")]
     pub external_billing_provider: i32,
     #[deprecated]
     #[prost(message, optional, tag = "4")]
     pub address: ::core::option::Option<Address>,
-    /// Determines when to charge for base package price / subscription fee.
+    /// Use PricingConfig.billing_period_start_date and PricingConfig.billing_period_end_date
+    #[deprecated]
     #[prost(message, optional, tag = "5")]
     pub contract_start_date: ::core::option::Option<Date>,
+    #[deprecated]
     #[prost(message, optional, tag = "6")]
     pub contract_end_date: ::core::option::Option<Date>,
 }
@@ -188,7 +193,15 @@ pub struct ContractMetadata {
     /// The set of BillingRules that the BillingRulesEngine has to execute for this contract.
     #[prost(string, tag = "3")]
     pub ruleset_version: ::prost::alloc::string::String,
+    /// Catch-all for overrides and information not covered above.
+    #[prost(message, optional, tag = "6")]
+    pub custom_options: ::core::option::Option<MetadataOptions>,
+    #[prost(message, optional, tag = "7")]
+    pub billing_features: ::core::option::Option<super::super::super::FeatureOptions>,
+    #[prost(uint64, tag = "8")]
+    pub package_id: u64,
     /// Includes information like plan ID, tier, etc.
+    #[deprecated]
     #[prost(message, optional, tag = "4")]
     pub package_metadata: ::core::option::Option<MetadataOptions>,
     /// Entitlements, used in frontend features or gating access to certain features.
@@ -197,11 +210,6 @@ pub struct ContractMetadata {
     #[deprecated]
     #[prost(message, optional, tag = "5")]
     pub features: ::core::option::Option<FeatureOptions>,
-    /// Catch-all for overrides and information not covered above.
-    #[prost(message, optional, tag = "6")]
-    pub custom_options: ::core::option::Option<MetadataOptions>,
-    #[prost(message, optional, tag = "7")]
-    pub billing_features: ::core::option::Option<super::super::super::FeatureOptions>,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
@@ -336,27 +344,84 @@ pub struct SharedSkuBudget {
     #[prost(enumeration = "super::super::super::Sku", repeated, tag = "4")]
     pub billing_skus: ::prost::alloc::vec::Vec<i32>,
 }
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct PaygBudget {
+    #[prost(uint64, tag = "1")]
+    pub budget_cents: u64,
+}
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct Reservation {
+    #[prost(uint64, tag = "1")]
+    pub reserved_price_cents: u64,
+    #[prost(oneof = "reservation::ReservedUnits", tags = "2, 3")]
+    pub reserved_units: ::core::option::Option<reservation::ReservedUnits>,
+}
+/// Nested message and enum types in `Reservation`.
+pub mod reservation {
+    #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Oneof)]
+    pub enum ReservedUnits {
+        #[prost(bool, tag = "2")]
+        IsUnlimited(bool),
+        #[prost(uint64, tag = "3")]
+        NumReservedUnits(u64),
+    }
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct LineItemUids {
+    #[prost(string, repeated, tag = "1")]
+    pub uids: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct UserConfig {
+    #[prost(message, optional, tag = "1")]
+    pub payg_budget: ::core::option::Option<PaygBudget>,
+    #[prost(message, optional, tag = "2")]
+    pub reservation: ::core::option::Option<Reservation>,
+    #[prost(oneof = "user_config::LineItems", tags = "3, 4")]
+    pub line_items: ::core::option::Option<user_config::LineItems>,
+}
+/// Nested message and enum types in `UserConfig`.
+pub mod user_config {
+    #[derive(Clone, PartialEq, Eq, Hash, ::prost::Oneof)]
+    pub enum LineItems {
+        #[prost(message, tag = "3")]
+        SpecificItems(super::LineItemUids),
+        #[prost(message, tag = "4")]
+        AllItems(()),
+    }
+}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PricingConfig {
-    #[prost(message, repeated, tag = "1")]
-    pub sku_configs: ::prost::alloc::vec::Vec<SkuConfig>,
-    #[prost(message, repeated, tag = "2")]
-    pub shared_sku_budgets: ::prost::alloc::vec::Vec<SharedSkuBudget>,
-    /// Determines when to reset quotas and create an invoice.
+    /// Determines when to reset quotas and charge the subscription price.
     #[prost(message, optional, tag = "3")]
     pub billing_period_start_date: ::core::option::Option<Date>,
     #[prost(message, optional, tag = "4")]
     pub billing_period_end_date: ::core::option::Option<Date>,
-    #[prost(uint64, tag = "5")]
-    pub max_spend_cents: u64,
-    /// Base price for the package.
-    #[prost(uint64, tag = "6")]
-    pub base_price_cents: u64,
     /// Determines when the on demand period for invoicing the organization starts and ends, even for annual plans we bill ondemand monthly
     #[prost(message, optional, tag = "7")]
     pub ondemand_period_start_date: ::core::option::Option<Date>,
     #[prost(message, optional, tag = "8")]
     pub ondemand_period_end_date: ::core::option::Option<Date>,
+    #[prost(message, optional, tag = "9")]
+    pub usage_watermark_ts: ::core::option::Option<::prost_types::Timestamp>,
+    #[prost(message, repeated, tag = "10")]
+    pub user_config: ::prost::alloc::vec::Vec<UserConfig>,
+    /// DEPRECATED: use package instead.
+    #[deprecated]
+    #[prost(uint64, tag = "6")]
+    pub base_price_cents: u64,
+    /// DEPRECATED: use package/user_parameters instead.
+    #[deprecated]
+    #[prost(message, repeated, tag = "1")]
+    pub sku_configs: ::prost::alloc::vec::Vec<SkuConfig>,
+    /// DEPRECATED: use package/user_parameters instead.
+    #[deprecated]
+    #[prost(message, repeated, tag = "2")]
+    pub shared_sku_budgets: ::prost::alloc::vec::Vec<SharedSkuBudget>,
+    /// DEPRECATED: use user_parameters instead
+    #[deprecated]
+    #[prost(uint64, tag = "5")]
+    pub max_spend_cents: u64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Contract {


### PR DESCRIPTION
Add the new Contract proto that will work with the package. Deprecated old fields that are now part of package

https://linear.app/getsentry/issue/REVENG-17/redefine-contract-protos