### PR TITLE
ref: Add line item quantity in usage pricer response

### DIFF
--- a/proto/sentry_protos/billing/v1/services/usage_pricer/v1/endpoint_usage_pricer.proto
+++ b/proto/sentry_protos/billing/v1/services/usage_pricer/v1/endpoint_usage_pricer.proto
@@ -43,6 +43,9 @@ message LineItemUsageSummary {
 
   // Net cents consumed by this line item in the billing period (after credits/trials applied).
   uint64 payg_spend_cents = 2;
+
+  // How much of the line item was consumed (in the line item's units)
+  uint64 quantity = 3;
 }
 
 message SharedLineItemUsageSummary {

--- a/rust/src/sentry_protos.billing.v1.services.usage_pricer.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.usage_pricer.v1.rs
@@ -43,6 +43,9 @@ pub struct LineItemUsageSummary {
     /// Net cents consumed by this line item in the billing period (after credits/trials applied).
     #[prost(uint64, tag = "2")]
     pub payg_spend_cents: u64,
+    /// How much of the line item was consumed (in the line item's units)
+    #[prost(uint64, tag = "3")]
+    pub quantity: u64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SharedLineItemUsageSummary {


### PR DESCRIPTION
We need the quantity of each line item in the invoice because the invoice shows both the $ cost and the quantity