### PR TITLE
ref: Add watermark for usage pricer start

### DIFF
--- a/proto/sentry_protos/billing/v1/services/usage_pricer/v1/endpoint_usage_pricer.proto
+++ b/proto/sentry_protos/billing/v1/services/usage_pricer/v1/endpoint_usage_pricer.proto
@@ -13,6 +13,7 @@ message UsagePricerRequest {
 
 message GetPriceForContractRequest {
   uint64 contract_id = 1;
+  google.protobuf.Timestamp usage_start_watermark_ts = 2;
 }
 
 message SKUUsageSummary {

--- a/rust/src/sentry_protos.billing.v1.services.usage_pricer.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.usage_pricer.v1.rs
@@ -12,6 +12,8 @@ pub struct UsagePricerRequest {
 pub struct GetPriceForContractRequest {
     #[prost(uint64, tag = "1")]
     pub contract_id: u64,
+    #[prost(message, optional, tag = "2")]
+    pub usage_start_watermark_ts: ::core::option::Option<::prost_types::Timestamp>,
 }
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct SkuUsageSummary {


### PR DESCRIPTION
We need to provide the start timestamp of usage data to use to make sure we start from immediately after the usage from the previous billing period