### PR TITLE
ref(billing-platform): Update seat based usage proto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.8.19"
+version = "0.8.20"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/services/usage/v1/endpoint_usage.proto
+++ b/proto/sentry_protos/billing/v1/services/usage/v1/endpoint_usage.proto
@@ -24,10 +24,18 @@ message CategorySeatUsage {
   uint64 count = 2;
 }
 
+// Seat usage data for a single day.
+message DailySeatUsage {
+  Date date = 1;
+  repeated CategorySeatUsage seats = 2;
+}
+
 message GetUsageResponse {
   // Usage broken down by day, each containing per-category usage.
   repeated DailyUsage days = 1;
-  repeated CategorySeatUsage seats = 2;
+  repeated DailySeatUsage seat_days = 3;
+
+  repeated CategorySeatUsage seats = 2 [deprecated = true]; // DEPRECATED: use seat_days
 }
 
 message GetUsageRequest {

--- a/py/tests/test_billing_usage_v1.py
+++ b/py/tests/test_billing_usage_v1.py
@@ -3,9 +3,12 @@ from google.protobuf.timestamp_pb2 import Timestamp
 from sentry_protos.billing.v1.data_category_pb2 import DataCategory
 from sentry_protos.billing.v1.date_pb2 import Date
 from sentry_protos.billing.v1.usage_data_pb2 import UsageData
+from sentry_protos.billing.v1.seat_category_pb2 import SeatCategory
 from sentry_protos.billing.v1.services.usage.v1.endpoint_usage_pb2 import (
+    CategorySeatUsage,
     CategoryUsage,
     DailyUsage,
+    DailySeatUsage,
     GetUsageRequest,
     GetUsageResponse,
 )
@@ -102,6 +105,28 @@ def test_get_usage_request_has_field():
     assert request_with_times.HasField("end")
 
 
+def test_daily_seat_usage():
+    day = Date(year=2024, month=1, day=1)
+    monitor_seats = CategorySeatUsage(
+        category=SeatCategory.SEAT_CATEGORY_MONITOR,
+        count=5,
+    )
+    uptime_seats = CategorySeatUsage(
+        category=SeatCategory.SEAT_CATEGORY_UPTIME,
+        count=3,
+    )
+    daily = DailySeatUsage(date=day, seats=[monitor_seats, uptime_seats])
+
+    assert daily.date.year == 2024
+    assert daily.date.month == 1
+    assert daily.date.day == 1
+    assert len(daily.seats) == 2
+    assert daily.seats[0].category == SeatCategory.SEAT_CATEGORY_MONITOR
+    assert daily.seats[0].count == 5
+    assert daily.seats[1].category == SeatCategory.SEAT_CATEGORY_UPTIME
+    assert daily.seats[1].count == 3
+
+
 def test_get_usage_response():
     day1 = DailyUsage(
         date=Date(year=2024, month=1, day=1),
@@ -125,7 +150,32 @@ def test_get_usage_response():
             ),
         ],
     )
-    response = GetUsageResponse(days=[day1, day2])
+    seat_day1 = DailySeatUsage(
+        date=Date(year=2024, month=1, day=1),
+        seats=[
+            CategorySeatUsage(
+                category=SeatCategory.SEAT_CATEGORY_MONITOR,
+                count=5,
+            ),
+        ],
+    )
+    seat_day2 = DailySeatUsage(
+        date=Date(year=2024, month=1, day=2),
+        seats=[
+            CategorySeatUsage(
+                category=SeatCategory.SEAT_CATEGORY_MONITOR,
+                count=7,
+            ),
+            CategorySeatUsage(
+                category=SeatCategory.SEAT_CATEGORY_UPTIME,
+                count=3,
+            ),
+        ],
+    )
+    response = GetUsageResponse(
+        days=[day1, day2],
+        seat_days=[seat_day1, seat_day2],
+    )
 
     assert len(response.days) == 2
     assert len(response.days[0].usage) == 1
@@ -134,10 +184,18 @@ def test_get_usage_response():
     assert response.days[1].usage[1].category == DataCategory.DATA_CATEGORY_TRANSACTION
     assert response.days[1].usage[1].data.over_quota == 200
 
+    assert len(response.seat_days) == 2
+    assert response.seat_days[0].date.year == 2024
+    assert len(response.seat_days[0].seats) == 1
+    assert response.seat_days[0].seats[0].count == 5
+    assert len(response.seat_days[1].seats) == 2
+    assert response.seat_days[1].seats[1].category == SeatCategory.SEAT_CATEGORY_UPTIME
+
 
 def test_get_usage_response_empty():
     response = GetUsageResponse()
     assert len(response.days) == 0
+    assert len(response.seat_days) == 0
 
 
 def test_get_usage_response_serialization_roundtrip():
@@ -149,6 +207,17 @@ def test_get_usage_response_serialization_roundtrip():
                     CategoryUsage(
                         category=DataCategory.DATA_CATEGORY_SPAN,
                         data=UsageData(total=10000, accepted=9500, dynamic_sampling=500),
+                    ),
+                ],
+            ),
+        ],
+        seat_days=[
+            DailySeatUsage(
+                date=Date(year=2024, month=1, day=1),
+                seats=[
+                    CategorySeatUsage(
+                        category=SeatCategory.SEAT_CATEGORY_MONITOR,
+                        count=10,
                     ),
                 ],
             ),
@@ -165,3 +234,8 @@ def test_get_usage_response_serialization_roundtrip():
     assert deserialized.days[0].usage[0].category == DataCategory.DATA_CATEGORY_SPAN
     assert deserialized.days[0].usage[0].data.total == 10000
     assert deserialized.days[0].usage[0].data.dynamic_sampling == 500
+
+    assert len(deserialized.seat_days) == 1
+    assert deserialized.seat_days[0].date.year == 2024
+    assert deserialized.seat_days[0].seats[0].category == SeatCategory.SEAT_CATEGORY_MONITOR
+    assert deserialized.seat_days[0].seats[0].count == 10

--- a/rust/src/sentry_protos.billing.v1.services.usage.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.usage.v1.rs
@@ -59,13 +59,21 @@ pub struct CategorySeatUsage {
     #[prost(uint64, tag = "2")]
     pub count: u64,
 }
+/// Seat usage data for a single day.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DailySeatUsage {
+    #[prost(message, optional, tag = "1")]
+    pub date: ::core::option::Option<super::super::super::Date>,
+    #[prost(message, repeated, tag = "2")]
+    pub seats: ::prost::alloc::vec::Vec<CategorySeatUsage>,
+}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetUsageResponse {
     /// Usage broken down by day, each containing per-category usage.
     #[prost(message, repeated, tag = "1")]
     pub days: ::prost::alloc::vec::Vec<DailyUsage>,
     #[prost(message, repeated, tag = "2")]
-    pub seats: ::prost::alloc::vec::Vec<CategorySeatUsage>,
+    pub seat_days: ::prost::alloc::vec::Vec<DailySeatUsage>,
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct GetUsageRequest {

--- a/rust/src/sentry_protos.billing.v1.services.usage.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.usage.v1.rs
@@ -72,8 +72,12 @@ pub struct GetUsageResponse {
     /// Usage broken down by day, each containing per-category usage.
     #[prost(message, repeated, tag = "1")]
     pub days: ::prost::alloc::vec::Vec<DailyUsage>,
-    #[prost(message, repeated, tag = "2")]
+    #[prost(message, repeated, tag = "3")]
     pub seat_days: ::prost::alloc::vec::Vec<DailySeatUsage>,
+    /// DEPRECATED: use seat_days
+    #[deprecated]
+    #[prost(message, repeated, tag = "2")]
+    pub seats: ::prost::alloc::vec::Vec<CategorySeatUsage>,
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct GetUsageRequest {

--- a/rust/tests/codegen_test.rs
+++ b/rust/tests/codegen_test.rs
@@ -18,7 +18,8 @@ use sentry_protos::billing::v1::SeatCategory;
 use sentry_protos::billing::v1::UsageData;
 use sentry_protos::billing::v1::services::contract::v1::{Contract, GetContractRequest};
 use sentry_protos::billing::v1::services::usage::v1::{
-    CategorySeatUsage, CategoryUsage, DailyUsage, GetUsageRequest, GetUsageResponse,
+    CategorySeatUsage, CategoryUsage, DailySeatUsage, DailyUsage, GetUsageRequest,
+    GetUsageResponse,
 };
 use sentry_protos::sentry::v1::RetryState;
 
@@ -64,9 +65,16 @@ fn roundtrip_get_usage_response() {
                 }),
             }],
         }],
-        seats: vec![CategorySeatUsage {
-            category: SeatCategory::Monitor as i32,
-            count: 5,
+        seat_days: vec![DailySeatUsage {
+            date: Some(Date {
+                year: 2026,
+                month: 1,
+                day: 15,
+            }),
+            seats: vec![CategorySeatUsage {
+                category: SeatCategory::Monitor as i32,
+                count: 5,
+            }],
         }],
     });
 }


### PR DESCRIPTION
closes https://linear.app/getsentry/issue/REVENG-41/update-seat-based-usage-protos-to-be-broken-down-by-date