### PR TITLE
ref: Use display units

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.8.19"
+version = "0.8.20"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/services/contract/v1/pricing_config.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/pricing_config.proto
@@ -60,7 +60,9 @@ message Reservation {
   uint64 reserved_price_cents = 1;
   oneof reserved_units {
     bool is_unlimited = 2;
-    uint64 num_reserved_units = 3;
+    uint64 num_reserved_units = 3 [deprecated = true]; // DEPRECATED: use converted_reserved_units
+    // Converted from the types base units to display units
+    float converted_reserved_units = 4;
   }
 }
 

--- a/proto/sentry_protos/billing/v1/services/package/v1/package.proto
+++ b/proto/sentry_protos/billing/v1/services/package/v1/package.proto
@@ -15,7 +15,9 @@ message LineItemConfig {
   // how many of this lineitem are included in the package, the customer can reserve more on their contract
   oneof included_reserved_units {
     bool is_unlimited = 5;
-    uint64 num_reserved_units = 6; // the type communicates whether the line item is unlimited or not, additionally reserved budget line items have a non-zero reserved_rate in addition to 0 reserved_units
+    uint64 num_reserved_units = 6 [deprecated = true]; // DEPRECATED: Use converted_reserved_units instead
+    // In display units
+    float converted_reserved_units = 8; // the type communicates whether the line item is unlimited or not, additionally reserved budget line items have a non-zero reserved_rate in addition to 0 reserved_units
   }
 
   sentry_protos.billing.v1.common.v1.LineItemDetails line_item = 7;

--- a/proto/sentry_protos/billing/v1/services/rate_card/v1/rate_card.proto
+++ b/proto/sentry_protos/billing/v1/services/rate_card/v1/rate_card.proto
@@ -12,7 +12,9 @@ message RateCardLineItem {
   // contract overrides, the default package values are used.
   oneof reserved_units {
     bool is_unlimited = 2;
-    uint64 num_reserved_units = 3;
+    uint64 num_reserved_units = 3 [deprecated = true]; // DEPRECATED: Use converted_reserved_units instead
+    // In display units
+    float converted_reserved_units = 6;
   }
   sentry_protos.billing.v1.common.v1.TieredPricingRate payg_rate = 4;
   sentry_protos.billing.v1.common.v1.TieredPricingRate reserved_rate = 5;

--- a/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
@@ -352,21 +352,26 @@ pub struct PaygBudget {
     #[prost(uint64, tag = "1")]
     pub budget_cents: u64,
 }
-#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct Reservation {
     #[prost(uint64, tag = "1")]
     pub reserved_price_cents: u64,
-    #[prost(oneof = "reservation::ReservedUnits", tags = "2, 3")]
+    #[prost(oneof = "reservation::ReservedUnits", tags = "2, 3, 4")]
     pub reserved_units: ::core::option::Option<reservation::ReservedUnits>,
 }
 /// Nested message and enum types in `Reservation`.
 pub mod reservation {
-    #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Oneof)]
+    #[derive(Clone, Copy, PartialEq, ::prost::Oneof)]
     pub enum ReservedUnits {
         #[prost(bool, tag = "2")]
         IsUnlimited(bool),
+        /// DEPRECATED: use converted_reserved_units
+        #[deprecated]
         #[prost(uint64, tag = "3")]
         NumReservedUnits(u64),
+        /// Converted from the types base units to display units
+        #[prost(float, tag = "4")]
+        ConvertedReservedUnits(f32),
     }
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
@@ -374,7 +379,7 @@ pub struct LineItemUids {
     #[prost(string, repeated, tag = "1")]
     pub uids: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UserConfig {
     #[prost(message, optional, tag = "1")]
     pub payg_budget: ::core::option::Option<PaygBudget>,

--- a/rust/src/sentry_protos.billing.v1.services.package.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.package.v1.rs
@@ -18,7 +18,7 @@ pub struct LineItemConfig {
         super::super::super::common::v1::LineItemDetails,
     >,
     /// how many of this lineitem are included in the package, the customer can reserve more on their contract
-    #[prost(oneof = "line_item_config::IncludedReservedUnits", tags = "5, 6")]
+    #[prost(oneof = "line_item_config::IncludedReservedUnits", tags = "5, 6, 8")]
     pub included_reserved_units: ::core::option::Option<
         line_item_config::IncludedReservedUnits,
     >,
@@ -26,13 +26,19 @@ pub struct LineItemConfig {
 /// Nested message and enum types in `LineItemConfig`.
 pub mod line_item_config {
     /// how many of this lineitem are included in the package, the customer can reserve more on their contract
-    #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Oneof)]
+    #[derive(Clone, Copy, PartialEq, ::prost::Oneof)]
     pub enum IncludedReservedUnits {
         #[prost(bool, tag = "5")]
         IsUnlimited(bool),
-        /// the type communicates whether the line item is unlimited or not, additionally reserved budget line items have a non-zero reserved_rate in addition to 0 reserved_units
+        /// DEPRECATED: Use converted_reserved_units instead
+        #[deprecated]
         #[prost(uint64, tag = "6")]
         NumReservedUnits(u64),
+        /// In display units
+        ///
+        /// the type communicates whether the line item is unlimited or not, additionally reserved budget line items have a non-zero reserved_rate in addition to 0 reserved_units
+        #[prost(float, tag = "8")]
+        ConvertedReservedUnits(f32),
     }
 }
 /// Represents a budget included in a package that is collectively used by one or more line items,

--- a/rust/src/sentry_protos.billing.v1.services.rate_card.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.rate_card.v1.rs
@@ -15,19 +15,24 @@ pub struct RateCardLineItem {
     >,
     /// The following values are the effective values *after* contract overrides have been resolved. If there are no
     /// contract overrides, the default package values are used.
-    #[prost(oneof = "rate_card_line_item::ReservedUnits", tags = "2, 3")]
+    #[prost(oneof = "rate_card_line_item::ReservedUnits", tags = "2, 3, 6")]
     pub reserved_units: ::core::option::Option<rate_card_line_item::ReservedUnits>,
 }
 /// Nested message and enum types in `RateCardLineItem`.
 pub mod rate_card_line_item {
     /// The following values are the effective values *after* contract overrides have been resolved. If there are no
     /// contract overrides, the default package values are used.
-    #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Oneof)]
+    #[derive(Clone, Copy, PartialEq, ::prost::Oneof)]
     pub enum ReservedUnits {
         #[prost(bool, tag = "2")]
         IsUnlimited(bool),
+        /// DEPRECATED: Use converted_reserved_units instead
+        #[deprecated]
         #[prost(uint64, tag = "3")]
         NumReservedUnits(u64),
+        /// In display units
+        #[prost(float, tag = "6")]
+        ConvertedReservedUnits(f32),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]


### PR DESCRIPTION
If num_reserved_units was meant to be in display units not base units then we need to represent it as a float (ie 5.1 GB)