### PR TITLE
ref: Add invoice guid

### DIFF
--- a/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_get_invoice.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_get_invoice.proto
@@ -6,6 +6,7 @@ import "sentry_protos/billing/v1/services/contract/v1/invoice.proto";
 
 message GetInvoiceRequest {
   uint64 invoice_id = 1;
+  string invoice_guid = 2;
 }
 
 message GetInvoiceResponse {

--- a/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
@@ -495,10 +495,12 @@ pub struct Invoice {
     #[prost(string, tag = "7")]
     pub guid: ::prost::alloc::string::String,
 }
-#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct GetInvoiceRequest {
     #[prost(uint64, tag = "1")]
     pub invoice_id: u64,
+    #[prost(string, tag = "2")]
+    pub invoice_guid: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetInvoiceResponse {


### PR DESCRIPTION
I'd like to use guid as much as possible so that it's easier to differentiate between a platform object and legacy object. For example if a stripe webhook payload contains a guid we can first check if a platform object exists, then fall back to a non-platform object. The regular id couldn't do that because it would have collisions