### PR TITLE
fix(billing): add missing invoice and billing details proto fields

### DIFF
--- a/proto/sentry_protos/billing/v1/services/billing_details/v1/billing_details.proto
+++ b/proto/sentry_protos/billing/v1/services/billing_details/v1/billing_details.proto
@@ -14,4 +14,7 @@ message Address {
 
 message BillingDetails {
   Address address = 1;
+  string display_address = 2;
+  string billing_email = 3;
+  string company_name = 4;
 }

--- a/proto/sentry_protos/billing/v1/services/contract/v1/invoice.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/invoice.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package sentry_protos.billing.v1.services.contract.v1;
 
+import "google/protobuf/timestamp.proto";
+
 // This is not the same as LineItemDetails, it includes
 // items not related to the package such as tax.
 message InvoiceLineItem {
@@ -15,4 +17,8 @@ message Invoice {
     repeated InvoiceLineItem line_items = 2;
     // Not just a sum of line items since there may be credit applied
     uint64 amount_billed = 3;
+    uint64 organization_id = 4;
+    bool paid = 5;
+    google.protobuf.Timestamp date_added = 6;
+    string guid = 7;
 }

--- a/rust/src/sentry_protos.billing.v1.services.billing_details.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.billing_details.v1.rs
@@ -20,6 +20,12 @@ pub struct Address {
 pub struct BillingDetails {
     #[prost(message, optional, tag = "1")]
     pub address: ::core::option::Option<Address>,
+    #[prost(string, tag = "2")]
+    pub display_address: ::prost::alloc::string::String,
+    #[prost(string, tag = "3")]
+    pub billing_email: ::prost::alloc::string::String,
+    #[prost(string, tag = "4")]
+    pub company_name: ::prost::alloc::string::String,
 }
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct GetBillingDetailsRequest {

--- a/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
@@ -472,6 +472,14 @@ pub struct Invoice {
     /// Not just a sum of line items since there may be credit applied
     #[prost(uint64, tag = "3")]
     pub amount_billed: u64,
+    #[prost(uint64, tag = "4")]
+    pub organization_id: u64,
+    #[prost(bool, tag = "5")]
+    pub paid: bool,
+    #[prost(message, optional, tag = "6")]
+    pub date_added: ::core::option::Option<::prost_types::Timestamp>,
+    #[prost(string, tag = "7")]
+    pub guid: ::prost::alloc::string::String,
 }
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct GetInvoiceRequest {


### PR DESCRIPTION
## Summary
- Add the missing `BillingDetails` fields used by the billing details service constructor in getsentry.
- Add the missing `Invoice` fields and `google.protobuf.Timestamp` import used by the contract service invoice constructor in getsentry.
- Regenerate Rust bindings to match the updated proto schema.

## Test plan
- [x] Verified branch diff includes only proto and generated Rust updates for the added fields.
- [x] Verified branch is rebased/pushed and ready for CI checks.
- [ ] CI (`buf-checks` / codegen checks) passes on the new PR.


Made with [Cursor](https://cursor.com)