### PR TITLE
ref: Add address to rollover contract request

### DIFF
--- a/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_rollover_contract.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_rollover_contract.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package sentry_protos.billing.v1.services.contract.v1;
 
 import "google/protobuf/timestamp.proto";
+import "sentry_protos/billing/v1/common/v1/address.proto";
 import "sentry_protos/billing/v1/services/contract/v1/invoice.proto";
 
 // Creates a new contract for a new billing period. Closes out the current contract by
@@ -11,6 +12,7 @@ message RolloverContractRequest {
   uint64 contract_id = 1;
   google.protobuf.Timestamp last_usage_ts = 2;
   repeated InvoiceLineItem line_items = 3;
+  sentry_protos.billing.v1.common.v1.Address address = 4;
 }
 
 message RolloverContractResponse {

--- a/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
@@ -581,6 +581,8 @@ pub struct RolloverContractRequest {
     pub last_usage_ts: ::core::option::Option<::prost_types::Timestamp>,
     #[prost(message, repeated, tag = "3")]
     pub line_items: ::prost::alloc::vec::Vec<InvoiceLineItem>,
+    #[prost(message, optional, tag = "4")]
+    pub address: ::core::option::Option<super::super::super::common::v1::Address>,
 }
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct RolloverContractResponse {


### PR DESCRIPTION
The invoicer service provides this to the contract service on contract rollover