### PR TITLE
feat: Add mark paid and mark failed invoice endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.8.25"
+version = "0.8.26"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_mark_invoice_paid.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_mark_invoice_paid.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package sentry_protos.billing.v1.services.contract.v1;
+
+// Marks an invoice as paid and clears its needs_charged flag so it is no longer
+// returned by GetUnchargedInvoices.
+message MarkInvoicePaidRequest {
+  uint64 invoice_id = 1;
+}
+
+message MarkInvoicePaidResponse {
+  // True if a matching invoice was found and updated.
+  bool updated = 1;
+}

--- a/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_record_failed_charge_attempt.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_record_failed_charge_attempt.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package sentry_protos.billing.v1.services.contract.v1;
+
+// Records a failed charge attempt against an invoice.
+message RecordFailedChargeAttemptRequest {
+  uint64 invoice_id = 1;
+}
+
+message RecordFailedChargeAttemptResponse {
+  // True if a matching invoice was found and updated.
+  bool updated = 1;
+}

--- a/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
@@ -607,6 +607,31 @@ pub struct ListInvoicesResponse {
     #[prost(uint32, tag = "4")]
     pub total: u32,
 }
+/// Marks an invoice as paid and clears its needs_charged flag so it is no longer
+/// returned by GetUnchargedInvoices.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct MarkInvoicePaidRequest {
+    #[prost(uint64, tag = "1")]
+    pub invoice_id: u64,
+}
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct MarkInvoicePaidResponse {
+    /// True if a matching invoice was found and updated.
+    #[prost(bool, tag = "1")]
+    pub updated: bool,
+}
+/// Records a failed charge attempt against an invoice.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct RecordFailedChargeAttemptRequest {
+    #[prost(uint64, tag = "1")]
+    pub invoice_id: u64,
+}
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct RecordFailedChargeAttemptResponse {
+    /// True if a matching invoice was found and updated.
+    #[prost(bool, tag = "1")]
+    pub updated: bool,
+}
 /// Creates a new contract for a new billing period. Closes out the current contract by
 /// creating an invoice and setting the last usage date
 #[derive(Clone, PartialEq, ::prost::Message)]


### PR DESCRIPTION
These endpoints are used to report the status back from the charge service