### PR TITLE
feat(explore): Add optional index field to AttributeKey for array element access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/snuba/v1/trace_item_attribute.proto
+++ b/proto/sentry_protos/snuba/v1/trace_item_attribute.proto
@@ -22,8 +22,7 @@ message AttributeKey {
   string name = 2;
 
   // Optional indexed access into an array-typed attribute (only meaningful when type == TYPE_ARRAY).
-  // Signed to allow negative indexing (e.g. -1 for the last element).
-  optional sint32 index = 3;
+  optional uint32 index = 3;
 }
 
 // this allow us to select single key such as span.attr1

--- a/proto/sentry_protos/snuba/v1/trace_item_attribute.proto
+++ b/proto/sentry_protos/snuba/v1/trace_item_attribute.proto
@@ -20,6 +20,10 @@ message AttributeKey {
   // `sentry.` to allow users to send attributes of the same name.
   // Exampe: `sentry.duration`, `sentry.span_id` etc
   string name = 2;
+
+  // Optional indexed access into an array-typed attribute (only meaningful when type == TYPE_ARRAY).
+  // Signed to allow negative indexing (e.g. -1 for the last element).
+  optional sint32 index = 3;
 }
 
 // this allow us to select single key such as span.attr1

--- a/rust/src/sentry_protos.snuba.v1.rs
+++ b/rust/src/sentry_protos.snuba.v1.rs
@@ -8,6 +8,10 @@ pub struct AttributeKey {
     /// Exampe: `sentry.duration`, `sentry.span_id` etc
     #[prost(string, tag = "2")]
     pub name: ::prost::alloc::string::String,
+    /// Optional indexed access into an array-typed attribute (only meaningful when type == TYPE_ARRAY).
+    /// Signed to allow negative indexing (e.g. -1 for the last element).
+    #[prost(sint32, optional, tag = "3")]
+    pub index: ::core::option::Option<i32>,
 }
 /// Nested message and enum types in `AttributeKey`.
 pub mod attribute_key {

--- a/rust/src/sentry_protos.snuba.v1.rs
+++ b/rust/src/sentry_protos.snuba.v1.rs
@@ -9,9 +9,8 @@ pub struct AttributeKey {
     #[prost(string, tag = "2")]
     pub name: ::prost::alloc::string::String,
     /// Optional indexed access into an array-typed attribute (only meaningful when type == TYPE_ARRAY).
-    /// Signed to allow negative indexing (e.g. -1 for the last element).
-    #[prost(sint32, optional, tag = "3")]
-    pub index: ::core::option::Option<i32>,
+    #[prost(uint32, optional, tag = "3")]
+    pub index: ::core::option::Option<u32>,
 }
 /// Nested message and enum types in `AttributeKey`.
 pub mod attribute_key {


### PR DESCRIPTION
Adds `optional sint32 index` on `AttributeKey` to support indexed access into array-typed attributes (e.g. `field[N]:value` syntax). 