### PR TITLE
feat(billing): add address to CreateContractRequest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.8.31"
+version = "0.8.32"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_create_contract.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_create_contract.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package sentry_protos.billing.v1.services.contract.v1;
 
+import "sentry_protos/billing/v1/common/v1/address.proto";
 import "sentry_protos/billing/v1/services/contract/v1/invoice.proto";
 import "sentry_protos/billing/v1/services/contract/v1/pricing_config.proto";
 
@@ -10,6 +11,7 @@ message CreateContractRequest {
   string package_uid = 2;
   repeated UserConfig user_configs = 3;
   repeated InvoiceLineItem line_items = 4;
+  sentry_protos.billing.v1.common.v1.Address address = 5;
 }
 
 message CreateContractResponse {

--- a/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
@@ -477,6 +477,8 @@ pub struct CreateContractRequest {
     pub user_configs: ::prost::alloc::vec::Vec<UserConfig>,
     #[prost(message, repeated, tag = "4")]
     pub line_items: ::prost::alloc::vec::Vec<InvoiceLineItem>,
+    #[prost(message, optional, tag = "5")]
+    pub address: ::core::option::Option<super::super::super::common::v1::Address>,
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct CreateContractResponse {


### PR DESCRIPTION
## Why
`CreateContractRequest` needs to carry billing address data so the contract creation flow can pass address details used by downstream invoice/receipt generation.

## Context
- Related getsentry change: https://github.com/getsentry/getsentry/pull/20264

## What Changed
- Added `sentry_protos.billing.v1.common.v1.Address address = 5;` to `CreateContractRequest`
- Imported common billing address proto in `endpoint_create_contract.proto`
- Regenerated Rust artifacts

## Compatibility Notes
- This is backward-compatible for proto3 clients/servers because it adds a new optional message field with a new tag (`5`) and does not change or reuse existing tags.

Made with [Cursor](https://cursor.com)