### PR TITLE
fix: update craft minVersion to 2.14.0 for auto-versioning support

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,4 +1,4 @@
-minVersion: 1.20.0
+minVersion: 2.14.0
 changelog: CHANGELOG.md
 changelogPolicy: auto
 github:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
The release workflow was failing with the error:
```
Auto-versioning requires minVersion >= 2.14.0 in .craft.yml
```

## Solution
Updated `.craft.yml` to set `minVersion: 2.14.0` (from `1.20.0`) to support the auto-versioning feature used in the release workflow.

## Testing
This fix will be validated when the next release is created.

Fixes the error from: https://github.com/getsentry/sentry-protos/actions/runs/25868176280/job/76015872880
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sentry.slack.com/archives/D09259VQFAP/p1778701368262669?thread_ts=1778701368.262669&cid=D09259VQFAP)

<div><a href="https://cursor.com/agents/bc-5efd8fa2-cf5d-523c-8a00-7b9304478794"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5efd8fa2-cf5d-523c-8a00-7b9304478794"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

