### PR TITLE
ci(release): Auto-release when proto schemas change on main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: release
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       version:
@@ -18,6 +21,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
     name: 'Release a new version'
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      !startsWith(github.event.head_commit.message, 'release:')
     steps:
       - name: Get auth token
         id: token
@@ -36,5 +42,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.token.outputs.token }}
         with:
-          version: ${{ github.event.inputs.version }}
-          force: ${{ github.event.inputs.force }}
+          version: ${{ github.event.inputs.version || 'auto' }}
+          force: ${{ github.event.inputs.force || 'false' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'proto/**'
   workflow_dispatch:
     inputs:
       version:

--- a/README.md
+++ b/README.md
@@ -93,11 +93,14 @@ The `Type` enum would be available as `sentry_protos::snuba::v1alpha::attribute_
 
 ## Releasing
 
-Use the `release` workflow in GitHub actions to create new releases. Each time a release is created, packages will be published for each supported language.
+Releases are automated on every merge to `main`. The `release` GitHub Actions workflow
+runs with `version=auto`, which creates the next version and publishes packages for each
+supported language.
 
-In this repo, click on Actions:
+### Manual release workflow dispatch
 
-![image](https://github.com/user-attachments/assets/ce9f638e-5f16-4ff7-9457-d92d2738dc06)
+If you need to manually run a release with explicit inputs (for example custom `version`
+or `force`), use the `release` workflow in GitHub Actions:
 
 Select `release`
 

--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ The `Type` enum would be available as `sentry_protos::snuba::v1alpha::attribute_
 
 ## Releasing
 
-Releases are automated on every merge to `main`. The `release` GitHub Actions workflow
-runs with `version=auto`, which creates the next version and publishes packages for each
-supported language.
+Releases are automated for merges to `main` that include changes under `proto/`.
+The `release` GitHub Actions workflow runs with `version=auto`, which creates
+the next version and publishes packages for each supported language.
 
 ### Manual release workflow dispatch
 


### PR DESCRIPTION
Automate releases on merges to `main` when the merge includes protobuf schema changes under `proto/**`, so version bumps and package publishing stay aligned with schema updates.

**Scoped auto-release trigger**

The `release` workflow now runs on `push` to `main` with a `paths` filter for `proto/**`, and uses `version=auto` by default for push-triggered runs.

**Manual override and loop prevention**

Manual `workflow_dispatch` remains available for explicit `version`/`force` inputs, and release-generated `release:` commits are ignored to prevent recursive runs.

README now documents the new trigger scope and the manual dispatch path.