### PR TITLE
ci: Limit PR workflow to proto and Buf config changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,11 @@ name: ci
 
 on:
   pull_request:
+    paths:
+      - 'proto/**'
+      - 'buf.yaml'
+      - 'buf.lock'
+      - 'buf.gen.yaml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
       - 'buf.yaml'
       - 'buf.lock'
       - 'buf.gen.yaml'
+      - 'build_rust/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
## Summary
- restrict the `ci` workflow to PRs that touch `proto/**` or Buf configuration files
- avoid running Buf checks and posting Buf update comments on unrelated pull requests
- keep CI behavior intact for proto schema and Buf config changes

## Test plan
- [x] reviewed `.github/workflows/ci.yml` diff to confirm only `pull_request.paths` was added
- [ ] open a non-proto PR and verify this workflow does not trigger
- [ ] open a proto or Buf-config PR and verify this workflow triggers

Made with [Cursor](https://cursor.com)