### PR TITLE
feat(trace-item-values): Add counts to response

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/snuba/v1/endpoint_trace_item_attributes.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_trace_item_attributes.proto
@@ -91,6 +91,7 @@ message TraceItemAttributeValuesRequest {
 message TraceItemAttributeValuesResponse {
   // all the values that matched the criteria specified in the request
   repeated string values = 1;
+  repeated int64 counts = 3;
 
   // page token for the next page of results
   PageToken page_token = 6;

--- a/rust/src/sentry_protos.snuba.v1.rs
+++ b/rust/src/sentry_protos.snuba.v1.rs
@@ -1738,6 +1738,8 @@ pub struct TraceItemAttributeValuesResponse {
     /// all the values that matched the criteria specified in the request
     #[prost(string, repeated, tag = "1")]
     pub values: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    #[prost(int64, repeated, tag = "3")]
+    pub counts: ::prost::alloc::vec::Vec<i64>,
     /// page token for the next page of results
     #[prost(message, optional, tag = "6")]
     pub page_token: ::core::option::Option<PageToken>,


### PR DESCRIPTION
- This adds counts to the response/orders by it so we get the most common values and know by how much