### PR TITLE
feat(billing-platform): Add billing_interval snapshot to Contract BillingConfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.11.0"
+version = "0.13.0"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/services/contract/v1/billing_config.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/billing_config.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package sentry_protos.billing.v1.services.contract.v1;
 
+import "sentry_protos/billing/v1/common/v1/billing_interval.proto";
+
 message Date {
   uint32 year = 1;
   uint32 month = 2;
@@ -57,4 +59,8 @@ message BillingConfig {
   // Use PricingConfig.billing_period_start_date and PricingConfig.billing_period_end_date
   Date contract_start_date = 5 [deprecated = true];
   Date contract_end_date = 6 [deprecated = true];
+
+  // Snapshot of the package billing interval at the time the contract was
+  // created. Frozen for the life of the contract.
+  sentry_protos.billing.v1.common.v1.BillingInterval billing_interval = 7;
 }

--- a/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
@@ -46,6 +46,10 @@ pub struct BillingConfig {
     #[deprecated]
     #[prost(message, optional, tag = "6")]
     pub contract_end_date: ::core::option::Option<Date>,
+    /// Snapshot of the package billing interval at the time the contract was
+    /// created. Frozen for the life of the contract.
+    #[prost(enumeration = "super::super::super::common::v1::BillingInterval", tag = "7")]
+    pub billing_interval: i32,
 }
 /// Indicates how the account is billed.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]


### PR DESCRIPTION
Adds a `BillingInterval billing_interval` field (number 7) to `BillingConfig` so a contract can carry the cadence it was signed under on the wire. The contract domain in getsentry will populate this from a snapshot taken at signup, so the cadence becomes a frozen attribute of the contract instead of something callers have to re-resolve from the package on every read.

**Scope**

Single-file proto change. The `BillingInterval` enum already exists in `proto/sentry_protos/billing/v1/common/v1/billing_interval.proto` (`UNSPECIFIED=0`, `MONTHLY=1`, `ANNUAL_BASE_MONTHLY_PAYG=2`); this PR just imports it and adds the field with a doc comment that it's frozen for the life of the contract.

**Consumer**

This is preparatory infrastructure for the consumer in getsentry/getsentry#20403, which itself is prep work for the larger annual-contract feature in getsentry/getsentry#20333. After this PR releases, #20403 will repin sentry-protos and start populating `Contract.billing_config.billing_interval`.

Refs getsentry/getsentry#20403
Refs getsentry/getsentry#20333