### PR TITLE
feat(devenv): guard sentry-protos worktree basename mismatches

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -2,7 +2,12 @@ if [ -f .env ]; then
     dotenv
 fi
 
-if ! command -v "devenv" >/dev/null; then
+expected_repo_name="$(awk -F'[][.]' '/^\[venv\./{print $3; exit}' devenv/config.ini 2>/dev/null)"
+
+if [ -n "$expected_repo_name" ] && [ "$(basename "$PWD")" != "$expected_repo_name" ]; then
+  echo "direnv: worktree basename '$(basename "$PWD")' does not match expected '$expected_repo_name'."
+  echo "direnv: skipping devenv sync. Move this checkout to a path ending in '/$expected_repo_name'."
+elif ! command -v "devenv" >/dev/null; then
   echo 'Sentry devenv can help simplify dev environment management.
 Try out with an install from:
 https://github.com/getsentry/devenv#install


### PR DESCRIPTION
Prevent `direnv` from failing with a Python `KeyError` when a `sentry-protos` worktree is created under a directory whose basename does not match the expected `venv` section name.

When the basename check fails, `.envrc` now prints a clear remediation message and skips `devenv sync` instead of attempting a broken sync path.

**Safer Worktree Startup**

This makes misnamed worktrees fail soft with actionable guidance, while preserving the existing setup flow for correctly named checkouts.

Made with [Cursor](https://cursor.com)