### PR TITLE
build(deps): widen grpcio ranges for modern Python

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 build
 protobuf==5.29.5
-grpcio==1.65.4
+grpcio>=1.66,<2
 grpc-stubs==1.53.0.5
-grpcio-tools==1.65.4
+grpcio-tools>=1.66,<2
 types-protobuf==5.27.0.20240626
 mypy-protobuf==3.6.0
 mypy==1.10.1


### PR DESCRIPTION
Update Python gRPC dependencies to avoid source builds on newer interpreters.

`grpcio` and `grpcio-tools` were pinned to 1.65.4, which fails on Python 3.14 because compatible wheels are not available. This change replaces strict pins with `<2` ranges so pip can resolve wheel-supported releases while preserving major-version compatibility.

This keeps local setup and ephemeral CI/dev environments from failing at `pip install -r requirements.txt` when they are not using the repo's preferred Python.

Made with [Cursor](https://cursor.com)