### PR TITLE
chore(devenv): add worktree bootstrap helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ pull requests.
 
 You'll need a local clone of this repository to start.
 
+### New worktrees
+
+For a newly created git worktree, bootstrap the local environment before running `make`:
+
+```shell
+./scripts/setup-worktree.sh
+```
+
+This runs `devenv sync` for the worktree and (when installed) enables direnv for the repo.
+
 ### Python
 
 From the root of `sentry-protos` run:

--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if ! command -v devenv >/dev/null 2>&1; then
+  echo "devenv is required to bootstrap this worktree." >&2
+  echo "Install instructions: https://github.com/getsentry/devenv#install" >&2
+  exit 1
+fi
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "${repo_root}"
+
+echo "Bootstrapping sentry-protos worktree at ${repo_root}"
+devenv sync
+
+if command -v direnv >/dev/null 2>&1 && [ -f .envrc ]; then
+  direnv allow "${repo_root}" >/dev/null 2>&1 || true
+fi
+
+echo "Worktree setup complete."


### PR DESCRIPTION
Add a dedicated helper script for newly created git worktrees.

Fresh worktrees often run `make` before a local `.venv` exists, which leads to ambient interpreter usage. `scripts/setup-worktree.sh` now bootstraps the worktree by running `devenv sync` and, when available, allows direnv for the repository.

README now documents this as the first step after creating a new worktree.

Made with [Cursor](https://cursor.com)