### PR TITLE
build(buf): use a workspace-local cache directory

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -2,6 +2,8 @@ if [ -f .env ]; then
     dotenv
 fi
 
+export BUF_CACHE_DIR="$PWD/.buf-cache"
+
 expected_repo_name="$(awk -F'[][.]' '/^\[venv\./{print $3; exit}' devenv/config.ini 2>/dev/null)"
 
 if [ -n "$expected_repo_name" ] && [ "$(basename "$PWD")" != "$expected_repo_name" ]; then

--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,6 @@ data/
 # Generated documentation
 /docs/build/*
 /docs/descriptor.pb
+
+# Local cache for buf CLI
+/.buf-cache/


### PR DESCRIPTION
Configure buf to use a cache directory inside the repository workspace.

`.envrc` now exports `BUF_CACHE_DIR=$PWD/.buf-cache`, and `.gitignore` excludes that folder. This avoids writes to `~/.cache/buf`, which are often blocked in sandboxed development environments.

The change is local-development only and does not alter protobuf schemas or release artifacts.