### PR TITLE
feat(billing): Added support for reserved budgets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/services/package/v1/package.proto
+++ b/proto/sentry_protos/billing/v1/services/package/v1/package.proto
@@ -35,6 +35,12 @@ message SharedLineItemPool {
 
   // Whether this LineItem is included in the base package or not (ie Seer)
   bool is_optional_add_on = 4;
+
+  // The unique line item details used when invoicing this shared pool.
+  sentry_protos.billing.v1.common.v1.LineItemDetails shared_line_item = 5;
+
+  // Cost of the shared line item pool, in cents.
+  uint64 base_price_cents = 6;
 }
 
 message PackageConfig {

--- a/proto/sentry_protos/billing/v1/services/package/v1/package.proto
+++ b/proto/sentry_protos/billing/v1/services/package/v1/package.proto
@@ -39,7 +39,7 @@ message SharedLineItemPool {
   // The unique line item details used when invoicing this shared pool.
   sentry_protos.billing.v1.common.v1.LineItemDetails shared_line_item = 5;
 
-  // Cost of the shared line item pool, in cents.
+  // Cost of the shared line item pool, in cents(a customer can pay $X and get $Y of credit, where X!=Y).
   uint64 base_price_cents = 6;
 }
 

--- a/rust/src/sentry_protos.billing.v1.services.package.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.package.v1.rs
@@ -54,6 +54,14 @@ pub struct SharedLineItemPool {
     /// Whether this LineItem is included in the base package or not (ie Seer)
     #[prost(bool, tag = "4")]
     pub is_optional_add_on: bool,
+    /// The unique line item details used when invoicing this shared pool.
+    #[prost(message, optional, tag = "5")]
+    pub shared_line_item: ::core::option::Option<
+        super::super::super::common::v1::LineItemDetails,
+    >,
+    /// Cost of the shared line item pool, in cents.
+    #[prost(uint64, tag = "6")]
+    pub base_price_cents: u64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PackageConfig {

--- a/rust/src/sentry_protos.billing.v1.services.package.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.package.v1.rs
@@ -59,7 +59,7 @@ pub struct SharedLineItemPool {
     pub shared_line_item: ::core::option::Option<
         super::super::super::common::v1::LineItemDetails,
     >,
-    /// Cost of the shared line item pool, in cents.
+    /// Cost of the shared line item pool, in cents(a customer can pay $X and get $Y of credit, where X!=Y).
     #[prost(uint64, tag = "6")]
     pub base_price_cents: u64,
 }


### PR DESCRIPTION
This PR adds fields to store the price of a reserved budget pool, as well as a unique line item for each shared pool. 