### PR TITLE
feat(billing): add tax id fields to billing details and contract requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/services/billing_details/v1/billing_details.proto
+++ b/proto/sentry_protos/billing/v1/services/billing_details/v1/billing_details.proto
@@ -22,5 +22,6 @@ message BillingDetails {
   optional string company_name = 3;
   optional string billing_email = 4;
   sentry_protos.billing.v1.common.v1.Address billing_address = 5;
+  // The customer's tax registration number (e.g. VAT ID), if on file.
   optional string tax_number = 6;
 }

--- a/proto/sentry_protos/billing/v1/services/billing_details/v1/billing_details.proto
+++ b/proto/sentry_protos/billing/v1/services/billing_details/v1/billing_details.proto
@@ -22,4 +22,5 @@ message BillingDetails {
   optional string company_name = 3;
   optional string billing_email = 4;
   sentry_protos.billing.v1.common.v1.Address billing_address = 5;
+  optional string tax_number = 6;
 }

--- a/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_create_contract.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_create_contract.proto
@@ -17,7 +17,8 @@ message CreateContractRequest {
   // supported interval.
   uint32 month_interval = 6;
   // The customer's tax registration number (e.g. VAT ID), used to determine
-  // tax treatment for this contract. Unset if none is on file.
+  // tax treatment for this contract (for example, reverse charge for
+  // tax-registered businesses). Unset if none is on file.
   optional string customer_tax_id = 7;
 }
 

--- a/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_create_contract.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_create_contract.proto
@@ -16,6 +16,9 @@ message CreateContractRequest {
   // supported_month_intervals. If unset, defaults to the package's first
   // supported interval.
   uint32 month_interval = 6;
+  // The customer's tax registration number (e.g. VAT ID), used to determine
+  // tax treatment for this contract. Unset if none is on file.
+  optional string customer_tax_id = 7;
 }
 
 message CreateContractResponse {

--- a/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_rollover_contract.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_rollover_contract.proto
@@ -19,7 +19,8 @@ message RolloverContractRequest {
   // pending change is being applied during this rollover.
   optional sentry_protos.billing.v1.common.v1.PendingChange pending_change = 5;
   // The customer's tax registration number (e.g. VAT ID), used to determine
-  // tax treatment for this contract. Unset if none is on file.
+  // tax treatment for this contract (for example, reverse charge for
+  // tax-registered businesses). Unset if none is on file.
   optional string customer_tax_id = 6;
 }
 

--- a/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_rollover_contract.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_rollover_contract.proto
@@ -18,6 +18,9 @@ message RolloverContractRequest {
   // The pending change to apply to the new contract, if any. Unset means no
   // pending change is being applied during this rollover.
   optional sentry_protos.billing.v1.common.v1.PendingChange pending_change = 5;
+  // The customer's tax registration number (e.g. VAT ID), used to determine
+  // tax treatment for this contract. Unset if none is on file.
+  optional string customer_tax_id = 6;
 }
 
 message RolloverContractResponse {

--- a/rust/src/sentry_protos.billing.v1.services.billing_details.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.billing_details.v1.rs
@@ -31,6 +31,8 @@ pub struct BillingDetails {
     pub billing_address: ::core::option::Option<
         super::super::super::common::v1::Address,
     >,
+    #[prost(string, optional, tag = "6")]
+    pub tax_number: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct GetBillingDetailsRequest {

--- a/rust/src/sentry_protos.billing.v1.services.billing_details.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.billing_details.v1.rs
@@ -31,6 +31,7 @@ pub struct BillingDetails {
     pub billing_address: ::core::option::Option<
         super::super::super::common::v1::Address,
     >,
+    /// The customer's tax registration number (e.g. VAT ID), if on file.
     #[prost(string, optional, tag = "6")]
     pub tax_number: ::core::option::Option<::prost::alloc::string::String>,
 }

--- a/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
@@ -494,7 +494,8 @@ pub struct CreateContractRequest {
     #[prost(uint32, tag = "6")]
     pub month_interval: u32,
     /// The customer's tax registration number (e.g. VAT ID), used to determine
-    /// tax treatment for this contract. Unset if none is on file.
+    /// tax treatment for this contract (for example, reverse charge for
+    /// tax-registered businesses). Unset if none is on file.
     #[prost(string, optional, tag = "7")]
     pub customer_tax_id: ::core::option::Option<::prost::alloc::string::String>,
 }
@@ -678,7 +679,8 @@ pub struct RolloverContractRequest {
         super::super::super::common::v1::PendingChange,
     >,
     /// The customer's tax registration number (e.g. VAT ID), used to determine
-    /// tax treatment for this contract. Unset if none is on file.
+    /// tax treatment for this contract (for example, reverse charge for
+    /// tax-registered businesses). Unset if none is on file.
     #[prost(string, optional, tag = "6")]
     pub customer_tax_id: ::core::option::Option<::prost::alloc::string::String>,
 }

--- a/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
@@ -493,6 +493,10 @@ pub struct CreateContractRequest {
     /// supported interval.
     #[prost(uint32, tag = "6")]
     pub month_interval: u32,
+    /// The customer's tax registration number (e.g. VAT ID), used to determine
+    /// tax treatment for this contract. Unset if none is on file.
+    #[prost(string, optional, tag = "7")]
+    pub customer_tax_id: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct CreateContractResponse {
@@ -673,6 +677,10 @@ pub struct RolloverContractRequest {
     pub pending_change: ::core::option::Option<
         super::super::super::common::v1::PendingChange,
     >,
+    /// The customer's tax registration number (e.g. VAT ID), used to determine
+    /// tax treatment for this contract. Unset if none is on file.
+    #[prost(string, optional, tag = "6")]
+    pub customer_tax_id: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct RolloverContractResponse {


### PR DESCRIPTION
## Summary

Adds the customer's tax registration number to the platform billing protos so contract invoicing can compute sales tax with the correct treatment (for example, EU reverse charge for tax-registered businesses).

## Context

This isn't a new concept — it exposes a value the billing system already stores per customer and already forwards to the tax provider:

- The customer's tax registration number (VAT / GST / …) is stored on `BillingDetails`, set and VAT-validated through the billing-details API.
- At tax-calculation time it is sent to the tax provider as the transaction's `businessIdentificationNo` (AvaTax), and a present tax id is what drives reverse-charge treatment for tax-registered businesses (e.g. in the EU/UK).

These fields add the two wire hops that were missing:

- `BillingDetails.tax_number` exposes the stored value over `GetBillingDetails`.
- `CreateContractRequest.customer_tax_id` / `RolloverContractRequest.customer_tax_id` let the caller forward it into contract creation and rollover, where tax is computed.

The two names mirror their respective domains: `tax_number` matches the persisted field, while `customer_tax_id` matches the tax-calculation input it feeds.

## Changes

| Message | File | New field |
| --- | --- | --- |
| `BillingDetails` | `billing_details/v1/billing_details.proto` | `optional string tax_number = 6` |
| `CreateContractRequest` | `contract/v1/endpoint_create_contract.proto` | `optional string customer_tax_id = 7` |
| `RolloverContractRequest` | `contract/v1/endpoint_rollover_contract.proto` | `optional string customer_tax_id = 6` |

`GetBillingDetailsResponse` already embeds `BillingDetails`, so it returns `tax_number` with no further change.

## Backwards compatibility

All three are new `optional` fields with previously-unused field numbers — additive only, with no field reuse, rename, or type change — so the change is backwards-compatible (`buf breaking` passes against `main`).

## Codegen

Rust bindings are regenerated and committed (`rust/src/…billing_details.v1.rs`, `…contract.v1.rs`). Python output is gitignored and regenerated by consumers.

REVENG-15
