### PR TITLE
feat(billing): add tax_number to BillingDetails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.22.2"
+version = "0.23.0"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/services/billing_details/v1/billing_details.proto
+++ b/proto/sentry_protos/billing/v1/services/billing_details/v1/billing_details.proto
@@ -22,4 +22,7 @@ message BillingDetails {
   optional string company_name = 3;
   optional string billing_email = 4;
   sentry_protos.billing.v1.common.v1.Address billing_address = 5;
+  // The customer's tax registration number (e.g. VAT ID) on file, used when
+  // determining tax treatment for the customer. Unset if none is on file.
+  optional string tax_number = 6;
 }

--- a/rust/src/sentry_protos.billing.v1.services.billing_details.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.billing_details.v1.rs
@@ -31,6 +31,10 @@ pub struct BillingDetails {
     pub billing_address: ::core::option::Option<
         super::super::super::common::v1::Address,
     >,
+    /// The customer's tax registration number (e.g. VAT ID) on file, used when
+    /// determining tax treatment for the customer. Unset if none is on file.
+    #[prost(string, optional, tag = "6")]
+    pub tax_number: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct GetBillingDetailsRequest {


### PR DESCRIPTION
## Summary

Adds an `optional string tax_number = 6` to `BillingDetails` (the customer's tax registration number, e.g. VAT ID), used when determining tax treatment.

Sales tax is **no longer** carried on the contract requests as a dedicated `sales_tax` field. It now flows through `line_items` as a typed `InvoiceLineItem` (see the typed line-item change this PR is stacked on). The field slots previously considered for `sales_tax` are reserved for hygiene:
- `CreateContractRequest`: `reserved 7;`
- `RolloverContractRequest`: `reserved 6;`

### Changes
- `BillingDetails.tax_number = 6` (new, optional string)
- `CreateContractRequest`: `reserved 7;`
- `RolloverContractRequest`: `reserved 6;`

Rust bindings regenerated via `make build-rust`; Python bindings via `make build-py` (`py/` is gitignored).

## Stacking
`main` → #293 (InvoiceLineItem.type) → **this PR** → #287 (tax_pending). Review/merge in order.

## Test plan
- `make build-py` + `make build-rust` succeed
- `buf lint` / `buf format` pass