### PR TITLE
feat(billing): add tax_pending to RolloverContractRequest

### DIFF
--- a/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_rollover_contract.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_rollover_contract.proto
@@ -18,6 +18,12 @@ message RolloverContractRequest {
   // The pending change to apply to the new contract, if any. Unset means no
   // pending change is being applied during this rollover.
   optional sentry_protos.billing.v1.common.v1.PendingChange pending_change = 5;
+
+  // Whether the tax for this invoice could not be computed at creation time
+  // (the tax provider was unavailable) and must be backfilled later. When set,
+  // the invoice is created without a tax line item and held back from charging
+  // until a sweep recomputes the tax.
+  bool tax_pending = 6;
 }
 
 message RolloverContractResponse {

--- a/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
@@ -691,6 +691,12 @@ pub struct RolloverContractRequest {
     pub pending_change: ::core::option::Option<
         super::super::super::common::v1::PendingChange,
     >,
+    /// Whether the tax for this invoice could not be computed at creation time
+    /// (the tax provider was unavailable) and must be backfilled later. When set,
+    /// the invoice is created without a tax line item and held back from charging
+    /// until a sweep recomputes the tax.
+    #[prost(bool, tag = "6")]
+    pub tax_pending: bool,
 }
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct RolloverContractResponse {


### PR DESCRIPTION
## Summary

Adds `bool tax_pending = 7` to `RolloverContractRequest`.

When the tax provider is unavailable at rollover time, the tax cannot be computed. `tax_pending` marks such an invoice so it is created **without a tax line item** and held back from charging until a later sweep recomputes and backfills the tax.

### Field layout (RolloverContractRequest)
| # | field | notes |
|---|-------|-------|
| 5 | `pending_change` | unchanged |
| 6 | — | `reserved` (former sales_tax slot, removed in #286) |
| 7 | `tax_pending` | **new**, bool |

Rust bindings regenerated via `make build-rust`; Python bindings via `make build-py` (`py/` is gitignored).

## Stacking
`main` → #293 (InvoiceLineItem.type) → #286 (tax_number) → **this PR**. Review/merge in order.

## Test plan
- `make build-py` + `make build-rust` succeed
- `buf lint` / `buf format` pass