### PR TITLE
feat(billing): add optional type to InvoiceLineItem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/services/contract/v1/invoice.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/invoice.proto
@@ -6,11 +6,16 @@ import "google/protobuf/timestamp.proto";
 import "sentry_protos/billing/v1/common/v1/address.proto";
 
 // This is not the same as LineItemDetails, it includes
-// items not related to the package such as tax.
+// items not related to the package such as tax. Each line item may carry an
+// optional type that classifies it (e.g. "tax") so consumers can treat it
+// specially without inspecting the description.
 message InvoiceLineItem {
   // Intentionally not a uint (some line items could be discounts)
   int64 amount_cents = 1;
   optional string description = 2;
+  // Optional classifier for the line item, e.g. "tax". Unset for ordinary
+  // priced line items.
+  optional string type = 3;
 }
 
 message Invoice {

--- a/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
@@ -445,7 +445,9 @@ pub struct Contract {
     pub pricing_config: ::core::option::Option<PricingConfig>,
 }
 /// This is not the same as LineItemDetails, it includes
-/// items not related to the package such as tax.
+/// items not related to the package such as tax. Each line item may carry an
+/// optional type that classifies it (e.g. "tax") so consumers can treat it
+/// specially without inspecting the description.
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct InvoiceLineItem {
     /// Intentionally not a uint (some line items could be discounts)
@@ -453,6 +455,10 @@ pub struct InvoiceLineItem {
     pub amount_cents: i64,
     #[prost(string, optional, tag = "2")]
     pub description: ::core::option::Option<::prost::alloc::string::String>,
+    /// Optional classifier for the line item, e.g. "tax". Unset for ordinary
+    /// priced line items.
+    #[prost(string, optional, tag = "3")]
+    pub r#type: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Invoice {


### PR DESCRIPTION
## Summary

Adds an `optional string type = 3` field to `InvoiceLineItem` (proto/sentry_protos/billing/v1/services/contract/v1/invoice.proto).

This lets a line item carry a classifier (e.g. `"tax"`) so consumers can treat it specially without parsing the human-readable `description`. It is the foundation for representing sales tax as an ordinary, typed entry in `line_items` rather than a dedicated request field.

### Field layout (InvoiceLineItem)
| # | field | notes |
|---|-------|-------|
| 1 | `amount_cents` | unchanged |
| 2 | `description` | unchanged |
| 3 | `type` | **new**, optional string classifier |

Rust bindings regenerated via `make build-rust`; Python bindings via `make build-py` (`py/` is gitignored).

## Test plan
- `make build-py` + `make build-rust` succeed
- `buf lint` / `buf format` pass