### PR TITLE
feat(billing): add invoice_item_types to LineItemDetails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/common/v1/line_item_details.proto
+++ b/proto/sentry_protos/billing/v1/common/v1/line_item_details.proto
@@ -10,6 +10,9 @@ message LineItemDetails {
   // Unique identifier for the line item.
   string uid = 1;
 
+  // InvoiceItemType identifiers for this SKU, keyed by billing context.
+  InvoiceItemTypes invoice_item_types = 2;
+
   // Customer-facing display name for the line item.
   string customer_facing_name = 3;
 
@@ -21,4 +24,20 @@ message LineItemDetails {
 
   // Defines how usage data is transformed into this line item.
   BillableMetric billable_metric = 6;
+}
+
+// InvoiceItemType identifiers for a single SKU, split by billing context.
+// Reserved, on-demand, and activated usage of the same SKU can each settle as a
+// distinct InvoiceItemType, so every context carries its own identifier instead
+// of collapsing into one. Contexts are optional because some SKUs (e.g. Seer)
+// fold their usage irregularly and do not populate every context.
+message InvoiceItemTypes {
+  // Type for reserved (prepaid) usage of this SKU.
+  optional string reserved = 1;
+
+  // Type for on-demand (pay-as-you-go) usage of this SKU.
+  optional string ondemand = 2;
+
+  // Type for activated usage of this SKU.
+  optional string activated = 3;
 }

--- a/rust/src/sentry_protos.billing.v1.common.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.common.v1.rs
@@ -224,6 +224,9 @@ pub struct LineItemDetails {
     /// Unique identifier for the line item.
     #[prost(string, tag = "1")]
     pub uid: ::prost::alloc::string::String,
+    /// InvoiceItemType identifiers for this SKU, keyed by billing context.
+    #[prost(message, optional, tag = "2")]
+    pub invoice_item_types: ::core::option::Option<InvoiceItemTypes>,
     /// Customer-facing display name for the line item.
     #[prost(string, tag = "3")]
     pub customer_facing_name: ::prost::alloc::string::String,
@@ -236,6 +239,23 @@ pub struct LineItemDetails {
     /// Defines how usage data is transformed into this line item.
     #[prost(message, optional, tag = "6")]
     pub billable_metric: ::core::option::Option<BillableMetric>,
+}
+/// InvoiceItemType identifiers for a single SKU, split by billing context.
+/// Reserved, on-demand, and activated usage of the same SKU can each settle as a
+/// distinct InvoiceItemType, so every context carries its own identifier instead
+/// of collapsing into one. Contexts are optional because some SKUs (e.g. Seer)
+/// fold their usage irregularly and do not populate every context.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct InvoiceItemTypes {
+    /// Type for reserved (prepaid) usage of this SKU.
+    #[prost(string, optional, tag = "1")]
+    pub reserved: ::core::option::Option<::prost::alloc::string::String>,
+    /// Type for on-demand (pay-as-you-go) usage of this SKU.
+    #[prost(string, optional, tag = "2")]
+    pub ondemand: ::core::option::Option<::prost::alloc::string::String>,
+    /// Type for activated usage of this SKU.
+    #[prost(string, optional, tag = "3")]
+    pub activated: ::core::option::Option<::prost::alloc::string::String>,
 }
 /// Stripe-specific payment information for an organization.
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]


### PR DESCRIPTION
This is for https://github.com/getsentry/getsentry/pull/20573

## What

Adds a nested `InvoiceItemTypes` message to `line_item_details.proto` and attaches it to `LineItemDetails` as `invoice_item_types` (field number 2, previously unused).

```proto
message LineItemDetails {
  string uid = 1;
  InvoiceItemTypes invoice_item_types = 2;  // new
  string customer_facing_name = 3;
  string plural = 4;
  UnitInfo units = 5;
  BillableMetric billable_metric = 6;
}

message InvoiceItemTypes {
  optional string reserved  = 1;
  optional string ondemand  = 2;
  optional string activated = 3;
}
```

## Why

A single SKU's **reserved**, **on-demand**, and **activated** usage can each settle as a *distinct* `InvoiceItemType`. Collocating those identifiers on the SKU's `LineItemDetails` lets getsentry declare them per SKU, instead of growing a shared enum every time a new SKU/context combination appears.

Each context is `optional` because not every SKU uses every context — some SKUs (e.g. Seer) fold their usage irregularly and only populate a subset.

## Bindings

- Rust bindings regenerated (`make build-rust`) — the tracked `.rs` now contains `InvoiceItemTypes` and `LineItemDetails.invoice_item_types`.
- Python bindings regenerated (`make build-py`); the `py/` output is gitignored and not part of this diff.
- `Cargo.lock` left at main's version (the build's version-bump drift was reverted).

## Compatibility

Purely additive — a new message and a new field on a previously-unused field number. No existing fields change.