### PR TITLE
ref(billing): Add flexible price to Reservation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/services/contract/v1/pricing_config.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/pricing_config.proto
@@ -4,6 +4,7 @@ package sentry_protos.billing.v1.services.contract.v1;
 
 import "google/protobuf/empty.proto";
 import "google/protobuf/timestamp.proto";
+import "sentry_protos/billing/v1/common/v1/flexible_price.proto";
 import "sentry_protos/billing/v1/services/contract/v1/billing_config.proto";
 import "sentry_protos/billing/v1/services/contract/v1/sku.proto";
 import "sentry_protos/billing/v1/sku.proto";
@@ -57,11 +58,12 @@ message PAYGBudget {
 }
 
 message Reservation {
-  uint64 reserved_price_cents = 1;
+  uint64 reserved_price_cents = 1 [deprecated = true];
   oneof reserved_units {
     bool is_unlimited = 2;
     uint64 num_reserved_units = 3;
   }
+  sentry_protos.billing.v1.common.v1.FlexiblePrice flexible_reserved_price_cents = 4;
 }
 
 message LineItemUids {

--- a/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
@@ -287,8 +287,13 @@ pub struct PaygBudget {
 }
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Reservation {
+    #[deprecated]
     #[prost(uint64, tag = "1")]
     pub reserved_price_cents: u64,
+    #[prost(message, optional, tag = "4")]
+    pub flexible_reserved_price_cents: ::core::option::Option<
+        super::super::super::common::v1::FlexiblePrice,
+    >,
     #[prost(oneof = "reservation::ReservedUnits", tags = "2, 3")]
     pub reserved_units: ::core::option::Option<reservation::ReservedUnits>,
 }


### PR DESCRIPTION
## Summary

- Deprecate `Reservation.reserved_price_cents` and add `flexible_reserved_price_cents: FlexiblePrice` (field 4) so reserved capacity on a contract can carry an annual-term override alongside the monthly base.
- Mirrors the existing FlexiblePrice migrations on `PackageConfig` (#288) and `SharedLineItemPool` (#294).
- This PR is schema-only; getsentry consumers are unchanged. Posting for the team to weigh in on the shape before wiring up annual reserved-line-item discounts.

## Why

REVENG-145 calls for applying the same annual discount we apply to the package base price to reserved line items. Today `Reservation.reserved_price_cents` is a flat `uint64` and is invoiced as-is in `create_invoice.subscription_line_items`, so there's no way to encode an annual `fixed` total alongside the monthly base.

After this lands, the resolver in `services/invoicer/pricing.py:compute_flexible_amount_cents` can be applied to reservations the same way it is for the package base.

## Test plan

- [ ] `buf lint` passes (ran via pre-commit on commit)
- [ ] `buf format` passes (ran via pre-commit on commit)
- [ ] CI rebuilds Python + Rust bindings cleanly
- [ ] Reviewers agree on naming (`flexible_reserved_price_cents`) and that putting the override on `Reservation` is the right home (alternative discussed: derive at invoice time from `LineItemConfig.reserved_rate` tiers on the package)

Refs REVENG-145