### PR TITLE
feat(billing): Add has_card_on_file to StripePaymentData

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/common/v1/payment_config.proto
+++ b/proto/sentry_protos/billing/v1/common/v1/payment_config.proto
@@ -6,6 +6,7 @@ package sentry_protos.billing.v1.common.v1;
 message StripePaymentData {
   optional string customer_stripe_id = 1;
   optional string default_payment_method_id = 2;
+  optional bool has_card_on_file = 3;
 }
 
 // Payment provider configuration with support for multiple providers.

--- a/rust/src/sentry_protos.billing.v1.common.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.common.v1.rs
@@ -246,6 +246,8 @@ pub struct StripePaymentData {
     pub default_payment_method_id: ::core::option::Option<
         ::prost::alloc::string::String,
     >,
+    #[prost(bool, optional, tag = "3")]
+    pub has_card_on_file: ::core::option::Option<bool>,
 }
 /// Payment provider configuration with support for multiple providers.
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]


### PR DESCRIPTION
Adds an `optional bool has_card_on_file = 3` field to `StripePaymentData`, letting consumers determine whether an org has a card on file without a separate RPC. The field is populated inside `BillingDetailsService.get_stripe_payment_data` from the local `PaymentMethod` mirror table, mirroring the legacy `Subscription.has_card_on_file()` check.

The immediate consumer is platform invoice PDF generation, which today hardcodes the auto-renewal disclaimer regardless of whether the org has a card on file (incorrectly shown for invoiced customers). The `getsentry` implementation lands in a separate follow-up PR.

Refs REVENG-155