### PR TITLE
feat(billing): add tax_number to contract requests and Invoice

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_create_contract.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_create_contract.proto
@@ -16,6 +16,10 @@ message CreateContractRequest {
   // supported_month_intervals. If unset, defaults to the package's first
   // supported interval.
   uint32 month_interval = 6;
+  // The customer's tax registration number at invoicing time, persisted on the
+  // created invoice for receipts and reverse-charge determination. Unset if none
+  // is on file.
+  optional string tax_number = 7;
 }
 
 message CreateContractResponse {

--- a/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_rollover_contract.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_rollover_contract.proto
@@ -18,6 +18,10 @@ message RolloverContractRequest {
   // The pending change to apply to the new contract, if any. Unset means no
   // pending change is being applied during this rollover.
   optional sentry_protos.billing.v1.common.v1.PendingChange pending_change = 5;
+  // The customer's tax registration number at invoicing time, persisted on the
+  // created invoice for receipts and reverse-charge determination. Unset if none
+  // is on file.
+  optional string tax_number = 6;
 }
 
 message RolloverContractResponse {

--- a/proto/sentry_protos/billing/v1/services/contract/v1/invoice.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/invoice.proto
@@ -29,4 +29,7 @@ message Invoice {
   string guid = 7;
   bool needs_charged = 8;
   sentry_protos.billing.v1.common.v1.Address address = 9;
+  // The customer's tax registration number as persisted at invoicing time.
+  // Unset if none was on file.
+  optional string tax_number = 10;
 }

--- a/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
@@ -401,6 +401,10 @@ pub struct Invoice {
     pub needs_charged: bool,
     #[prost(message, optional, tag = "9")]
     pub address: ::core::option::Option<super::super::super::common::v1::Address>,
+    /// The customer's tax registration number as persisted at invoicing time.
+    /// Unset if none was on file.
+    #[prost(string, optional, tag = "10")]
+    pub tax_number: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct OptionValue {
@@ -499,6 +503,11 @@ pub struct CreateContractRequest {
     /// supported interval.
     #[prost(uint32, tag = "6")]
     pub month_interval: u32,
+    /// The customer's tax registration number at invoicing time, persisted on the
+    /// created invoice for receipts and reverse-charge determination. Unset if none
+    /// is on file.
+    #[prost(string, optional, tag = "7")]
+    pub tax_number: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct CreateContractResponse {
@@ -691,6 +700,11 @@ pub struct RolloverContractRequest {
     pub pending_change: ::core::option::Option<
         super::super::super::common::v1::PendingChange,
     >,
+    /// The customer's tax registration number at invoicing time, persisted on the
+    /// created invoice for receipts and reverse-charge determination. Unset if none
+    /// is on file.
+    #[prost(string, optional, tag = "6")]
+    pub tax_number: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct RolloverContractResponse {


### PR DESCRIPTION
Adds an optional `tax_number` field to three contract-service messages so the customer's tax registration number is carried into and persisted on the invoice it produces.

- `CreateContractRequest.tax_number` (field 7)
- `RolloverContractRequest.tax_number` (field 6)
- `Invoice.tax_number` (field 10)

## Why

Today the invoicer resolves the customer's tax number to compute tax, but the contract service has no field to receive it, so the value is sent to the tax provider and then discarded. Carrying it on the create and rollover requests lets the contract service snapshot the tax number that was in effect at invoicing time, and exposing it on `Invoice` lets receipts render that persisted value (and re-derive reverse-charge treatment) instead of re-reading the customer's current billing details, which may have changed since.

The Rust bindings are regenerated; the Python bindings are generated at build time and not committed.

## Note

The in-flight tax_pending PR #287 currently claims field 6 on `RolloverContractRequest` and will be renumbered to 7 after this merges.