### PR TITLE
feat(billing): scope pending changes to contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.26.0"
+version = "0.27.1"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/services/pending_change/v1/endpoint_add_pending_user_config.proto
+++ b/proto/sentry_protos/billing/v1/services/pending_change/v1/endpoint_add_pending_user_config.proto
@@ -13,6 +13,9 @@ message AddPendingUserConfigRequest {
   // The pending user config to add (PAYG budget and/or reservation overrides
   // for a set of line items).
   sentry_protos.billing.v1.common.v1.PendingUserConfig user_config = 2;
+
+  // The contract this change is staged to apply to.
+  uint64 target_contract_id = 3;
 }
 
 message AddPendingUserConfigResponse {}

--- a/proto/sentry_protos/billing/v1/services/pending_change/v1/endpoint_clear_pending_change.proto
+++ b/proto/sentry_protos/billing/v1/services/pending_change/v1/endpoint_clear_pending_change.proto
@@ -14,6 +14,9 @@ message ClearPendingChangeRequest {
   // leaves the pending change with no remaining changes, it is removed
   // entirely.
   bool on_demand_only = 2;
+
+  // If set, only clear a pending change staged for this contract.
+  optional uint64 target_contract_id = 3;
 }
 
 message ClearPendingChangeResponse {

--- a/proto/sentry_protos/billing/v1/services/pending_change/v1/endpoint_get_pending_change.proto
+++ b/proto/sentry_protos/billing/v1/services/pending_change/v1/endpoint_get_pending_change.proto
@@ -7,10 +7,17 @@ import "sentry_protos/billing/v1/common/v1/pending_change.proto";
 // Fetches the active pending change for an organization, if any.
 message GetPendingChangeRequest {
   uint64 organization_id = 1;
+
+  // If set, only return a pending change staged for this contract.
+  optional uint64 target_contract_id = 2;
 }
 
 message GetPendingChangeResponse {
   // The active pending change for the org. Unset if no change is currently
   // staged.
   optional sentry_protos.billing.v1.common.v1.PendingChange pending_change = 1;
+
+  // The contract this pending change is staged for. Set when pending_change is
+  // set.
+  optional uint64 target_contract_id = 2;
 }

--- a/proto/sentry_protos/billing/v1/services/pending_change/v1/endpoint_set_pending_month_interval.proto
+++ b/proto/sentry_protos/billing/v1/services/pending_change/v1/endpoint_set_pending_month_interval.proto
@@ -12,6 +12,9 @@ message SetPendingMonthIntervalRequest {
   // The contract month_interval the subscription will switch to at the next
   // rollover.
   uint32 month_interval = 2;
+
+  // The contract this change is staged to apply to.
+  uint64 target_contract_id = 3;
 }
 
 message SetPendingMonthIntervalResponse {}

--- a/proto/sentry_protos/billing/v1/services/pending_change/v1/endpoint_set_pending_package.proto
+++ b/proto/sentry_protos/billing/v1/services/pending_change/v1/endpoint_set_pending_package.proto
@@ -10,6 +10,9 @@ message SetPendingPackageRequest {
 
   // The package the subscription will switch to at the next rollover.
   string package_id = 2;
+
+  // The contract this change is staged to apply to.
+  uint64 target_contract_id = 3;
 }
 
 message SetPendingPackageResponse {}

--- a/rust/src/sentry_protos.billing.v1.services.pending_change.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.pending_change.v1.rs
@@ -12,6 +12,9 @@ pub struct AddPendingUserConfigRequest {
     pub user_config: ::core::option::Option<
         super::super::super::common::v1::PendingUserConfig,
     >,
+    /// The contract this change is staged to apply to.
+    #[prost(uint64, tag = "3")]
+    pub target_contract_id: u64,
 }
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct AddPendingUserConfigResponse {}
@@ -29,6 +32,9 @@ pub struct ClearPendingChangeRequest {
     /// entirely.
     #[prost(bool, tag = "2")]
     pub on_demand_only: bool,
+    /// If set, only clear a pending change staged for this contract.
+    #[prost(uint64, optional, tag = "3")]
+    pub target_contract_id: ::core::option::Option<u64>,
 }
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ClearPendingChangeResponse {
@@ -42,6 +48,9 @@ pub struct ClearPendingChangeResponse {
 pub struct GetPendingChangeRequest {
     #[prost(uint64, tag = "1")]
     pub organization_id: u64,
+    /// If set, only return a pending change staged for this contract.
+    #[prost(uint64, optional, tag = "2")]
+    pub target_contract_id: ::core::option::Option<u64>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetPendingChangeResponse {
@@ -51,6 +60,10 @@ pub struct GetPendingChangeResponse {
     pub pending_change: ::core::option::Option<
         super::super::super::common::v1::PendingChange,
     >,
+    /// The contract this pending change is staged for. Set when pending_change is
+    /// set.
+    #[prost(uint64, optional, tag = "2")]
+    pub target_contract_id: ::core::option::Option<u64>,
 }
 /// Sets the pending month_interval on the org's pending change. Creates a
 /// pending change if none exists, or updates the month_interval on the
@@ -64,6 +77,9 @@ pub struct SetPendingMonthIntervalRequest {
     /// rollover.
     #[prost(uint32, tag = "2")]
     pub month_interval: u32,
+    /// The contract this change is staged to apply to.
+    #[prost(uint64, tag = "3")]
+    pub target_contract_id: u64,
 }
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct SetPendingMonthIntervalResponse {}
@@ -77,6 +93,9 @@ pub struct SetPendingPackageRequest {
     /// The package the subscription will switch to at the next rollover.
     #[prost(string, tag = "2")]
     pub package_id: ::prost::alloc::string::String,
+    /// The contract this change is staged to apply to.
+    #[prost(uint64, tag = "3")]
+    pub target_contract_id: u64,
 }
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct SetPendingPackageResponse {}


### PR DESCRIPTION
## Summary
- add target_contract_id to pending-change get/clear APIs
- require target_contract_id on pending-change staging APIs
- expose target_contract_id in get responses for callers/debugging

## Test plan
- make build-py
- pre-commit run --files proto/sentry_protos/billing/v1/services/pending_change/v1/endpoint_add_pending_user_config.proto proto/sentry_protos/billing/v1/services/pending_change/v1/endpoint_clear_pending_change.proto proto/sentry_protos/billing/v1/services/pending_change/v1/endpoint_get_pending_change.proto proto/sentry_protos/billing/v1/services/pending_change/v1/endpoint_set_pending_month_interval.proto proto/sentry_protos/billing/v1/services/pending_change/v1/endpoint_set_pending_package.proto