### PR TITLE
Add admin_title field to PackageConfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/services/package/v1/package.proto
+++ b/proto/sentry_protos/billing/v1/services/package/v1/package.proto
@@ -67,4 +67,7 @@ message PackageConfig {
   // Number-of-months billing intervals this package offers.
   // [1] = monthly only, [1, 12] = monthly or annual, [12] = annual only.
   repeated uint32 supported_month_intervals = 7;
+
+  // Title shown in admin interfaces, not customer-facing.
+  string admin_title = 9;
 }

--- a/rust/src/sentry_protos.billing.v1.services.package.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.package.v1.rs
@@ -113,6 +113,9 @@ pub struct PackageConfig {
     /// \[1\] = monthly only, \[1, 12\] = monthly or annual, \[12\] = annual only.
     #[prost(uint32, repeated, tag = "7")]
     pub supported_month_intervals: ::prost::alloc::vec::Vec<u32>,
+    /// Title shown in admin interfaces, not customer-facing.
+    #[prost(string, tag = "9")]
+    pub admin_title: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct GetPackageRequest {


### PR DESCRIPTION
Add an `admin_title` string field to `PackageConfig` for displaying a title in admin interfaces that is distinct from the customer-facing `title`.

Uses field tag `9` (next available after `supported_month_intervals` at tag 7 and `flexible_base_price_cents` at tag 8). Regenerated the Rust bindings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)