### PR TITLE
feat(billing-platform): add BillingDetailsService.get_card_location endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/services/billing_details/v1/endpoint_get_card_location.proto
+++ b/proto/sentry_protos/billing/v1/services/billing_details/v1/endpoint_get_card_location.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+package sentry_protos.billing.v1.services.billing_details.v1;
+
+// Fetches the location facts cached from the organization's default card on
+// file. Reads only the webhook-synced payment method row — never Stripe — so
+// callers on the invoicing path don't block on a vendor round-trip.
+message GetCardLocationRequest {
+  uint64 organization_id = 1;
+}
+
+message GetCardLocationResponse {
+  // Postal code recorded for the default card on file. Unset when there is no
+  // card, or the card has no postal code.
+  optional string postal_code = 1;
+  // Country where the card was issued (not the customer's billing country).
+  // Unset when there is no card on file.
+  optional string country_code = 2;
+}

--- a/rust/src/sentry_protos.billing.v1.services.billing_details.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.billing_details.v1.rs
@@ -46,6 +46,25 @@ pub struct GetBillingDetailsResponse {
     #[prost(message, optional, tag = "1")]
     pub billing_details: ::core::option::Option<BillingDetails>,
 }
+/// Fetches the location facts cached from the organization's default card on
+/// file. Reads only the webhook-synced payment method row — never Stripe — so
+/// callers on the invoicing path don't block on a vendor round-trip.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct GetCardLocationRequest {
+    #[prost(uint64, tag = "1")]
+    pub organization_id: u64,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct GetCardLocationResponse {
+    /// Postal code recorded for the default card on file. Unset when there is no
+    /// card, or the card has no postal code.
+    #[prost(string, optional, tag = "1")]
+    pub postal_code: ::core::option::Option<::prost::alloc::string::String>,
+    /// Country where the card was issued (not the customer's billing country).
+    /// Unset when there is no card on file.
+    #[prost(string, optional, tag = "2")]
+    pub country_code: ::core::option::Option<::prost::alloc::string::String>,
+}
 /// Fetches lightweight identity fields for an organization. Used by callers
 /// that need slug/name/default_user_id without pulling the full Organization
 /// record across service boundaries.


### PR DESCRIPTION
## Summary

Promotes the `GetCardLocation` request/response from getsentry-side dataclass prototypes into real protobuf messages, adding a `get_card_location` endpoint to the billing-details service.

Follow-up to a review on getsentry PR #20532: https://github.com/getsentry/getsentry/pull/20532#discussion_r3404082894 — the dataclasses were merged as-is with the agreement to land the protos separately.

## What

New `proto/sentry_protos/billing/v1/services/billing_details/v1/endpoint_get_card_location.proto`:

- `GetCardLocationRequest { uint64 organization_id = 1; }`
- `GetCardLocationResponse { optional string postal_code = 1; optional string country_code = 2; }`

These mirror the existing dataclasses on `BillingDetailsService.get_card_location` in getsentry (location facts cached from the org's default card on file; the country is where the card was *issued*, not the billing country).

## Why `optional`

The getsentry dataclass response types both fields as `str | None`. Python protobuf scalars never return `None`, so `optional string` (explicit field presence via `HasField`) is the faithful mapping — unset ≠ empty string. This matches the existing `optional string` usage in `endpoint_get_organization_metadata.proto` in this same service.

## Generated bindings

Regenerated Rust bindings (`rust/src/sentry_protos.billing.v1.services.billing_details.v1.rs`) via `make build-rust`. Python bindings are gitignored and generated at build/package time. `buf-lint` + `buf-format` pass.

`Cargo.lock` carries a 1-line `sentry_protos 0.28.0 → 0.29.0` sync: `main`'s `Cargo.toml`/`VERSION` are already 0.29.0 (release 93fe71e) but the lockfile lagged; `make build-rust` refreshed it.

## Follow-up

getsentry adoption (swapping the dataclasses for these protos on `BillingDetailsService.get_card_location` and its consumers) is a separate getsentry PR.
