### PR TITLE
feat(billing-platform): add batched ChargeService.list_charges_for_invoice_ids (REVENG-157)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/services/charge/v1/endpoint_list_charges.proto
+++ b/proto/sentry_protos/billing/v1/services/charge/v1/endpoint_list_charges.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package sentry_protos.billing.v1.services.charge.v1;
 
+import "sentry_protos/billing/v1/services/charge/v1/charge.proto";
+
 message Charge {
   uint64 amount_cents = 1;
   bool paid = 2;
@@ -16,4 +18,23 @@ message ListChargesForInvoiceRequest {
 
 message ListChargesForInvoiceResponse {
   repeated Charge charges = 1;
+}
+
+// Batched variant for paginated invoice surfaces. Returns
+// ``PlatformCharge`` (the canonical projection, with embedded refunds via
+// ``PlatformCharge.refunds``) for every charge tied to any of the
+// requested invoices, so callers get full per-invoice charge + refund
+// state in one round trip. Avoids the N+1 of fetching refunds or
+// charges per invoice when rendering paginated invoice lists.
+message ListChargesForInvoiceIdsRequest {
+  repeated uint64 invoice_ids = 1;
+}
+
+message ListChargesForInvoiceIdsResponse {
+  // Flat list of charges across all requested invoices, ordered by
+  // ``(invoice_id, date_added)`` ascending. Each ``PlatformCharge``
+  // carries its ``invoice_id`` and embedded ``refunds``; group by
+  // ``charge.invoice_id`` to reconstruct per-invoice state. Invoices
+  // with no charges simply don't appear.
+  repeated PlatformCharge charges = 1;
 }

--- a/rust/src/sentry_protos.billing.v1.services.charge.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.charge.v1.rs
@@ -168,6 +168,27 @@ pub struct ListChargesForInvoiceResponse {
     #[prost(message, repeated, tag = "1")]
     pub charges: ::prost::alloc::vec::Vec<Charge>,
 }
+/// Batched variant for paginated invoice surfaces. Returns
+/// `PlatformCharge` (the canonical projection, with embedded refunds via
+/// `PlatformCharge.refunds`) for every charge tied to any of the
+/// requested invoices, so callers get full per-invoice charge + refund
+/// state in one round trip. Avoids the N+1 of fetching refunds or
+/// charges per invoice when rendering paginated invoice lists.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ListChargesForInvoiceIdsRequest {
+    #[prost(uint64, repeated, tag = "1")]
+    pub invoice_ids: ::prost::alloc::vec::Vec<u64>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListChargesForInvoiceIdsResponse {
+    /// Flat list of charges across all requested invoices, ordered by
+    /// `(invoice_id, date_added)` ascending. Each `PlatformCharge`
+    /// carries its `invoice_id` and embedded `refunds`; group by
+    /// `charge.invoice_id` to reconstruct per-invoice state. Invoices
+    /// with no charges simply don't appear.
+    #[prost(message, repeated, tag = "1")]
+    pub charges: ::prost::alloc::vec::Vec<PlatformCharge>,
+}
 /// Lists every recorded refund associated with the charges for a single
 /// platform invoice. Callers in the presentation layer use this to render
 /// invoice-level refund state without crossing the charge service boundary.


### PR DESCRIPTION
## Summary

Adds a batched endpoint that returns `PlatformCharge` (the canonical projection, with refunds embedded via `PlatformCharge.refunds` from [#303](https://github.com/getsentry/sentry-protos/pull/303)) for every charge tied to any of a list of invoices.

- **`services/charge/v1/endpoint_list_charges.proto`** — new `ListChargesForInvoiceIdsRequest` (`repeated uint64 invoice_ids`) + `ListChargesForInvoiceIdsResponse` (flat list of `PlatformCharge` ordered by `(invoice_id, date_added)`).

## Why

[getsentry#20613](https://github.com/getsentry/getsentry/pull/20613) hit a Cursor-bot-flagged N+1 in the customer invoices list — paginated rendering was calling `ChargeService.list_refunds_by_invoice` once per invoice. Earlier review feedback from Noah ([getsentry#20611 thread](https://github.com/getsentry/getsentry/pull/20611#discussion_r3397952041)) pointed at the same pattern: derive aggregates from per-row data, batch where possible.

This PR went with **charges-with-embedded-refunds** rather than a separate `list_refunds_by_invoice_ids` because:

1. **It leverages existing proto surface.** `PlatformCharge.refunds` already exists (added in #303); we just need a batch method that populates and returns it.
2. **It sets up admin surfaces.** Admin invoice details (deferred follow-up from getsentry#20613) wants full charge + refund detail in one round trip — this is the right shape.
3. **It still solves the customer-list case.** Consumers needing only refund totals sum `charge.refunds[*].amount_cents` grouped by `charge.invoice_id`.

The singleton `ListChargesForInvoiceRequest` / slim `Charge` type in the same file (dormant, defined in [#211](https://github.com/getsentry/sentry-protos/pull/211) but never implemented) is left as-is — deferring its deprecation to a separate proto-policy follow-up.

## Test plan

- [ ] Rust + Python bindings regenerated by CI
- [ ] `buf breaking` passes (verified locally — additive only)
- [ ] Once released + sentry pin bumped, consumed by getsentry#20613's `_PlatformInvoiceSource` to eliminate the N+1

🤖 Generated with [Claude Code](https://claude.com/claude-code)