### PR TITLE
feat(billing): Added retry charge endpoint protos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_retry_charge.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_retry_charge.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package sentry_protos.billing.v1.services.contract.v1;
 
 message RetryChargeRequest {
-  uint64 invoice_id = 1;
+  string invoice_guid = 1;
 }
 
 message RetryChargeResponse {

--- a/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_retry_charge.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_retry_charge.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package sentry_protos.billing.v1.services.contract.v1;
+
+import "sentry_protos/billing/v1/services/contract/v1/invoice.proto";
+
+message RetryChargeRequest {
+  Invoice invoice = 1;
+}
+
+message RetryChargeResponse {
+  Invoice invoice = 1;
+}

--- a/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_retry_charge.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_retry_charge.proto
@@ -2,12 +2,10 @@ syntax = "proto3";
 
 package sentry_protos.billing.v1.services.contract.v1;
 
-import "sentry_protos/billing/v1/services/contract/v1/invoice.proto";
-
 message RetryChargeRequest {
-  Invoice invoice = 1;
+  uint64 invoice_id = 1;
 }
 
 message RetryChargeResponse {
-  Invoice invoice = 1;
+  bool updated = 1;
 }

--- a/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
@@ -673,6 +673,16 @@ pub struct RecordFailedChargeAttemptResponse {
     #[prost(message, optional, tag = "3")]
     pub next_payment_attempt: ::core::option::Option<::prost_types::Timestamp>,
 }
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RetryChargeRequest {
+    #[prost(message, optional, tag = "1")]
+    pub invoice: ::core::option::Option<Invoice>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RetryChargeResponse {
+    #[prost(message, optional, tag = "1")]
+    pub invoice: ::core::option::Option<Invoice>,
+}
 /// Creates a new contract for a new billing period. Closes out the current contract by
 /// creating an invoice and setting the last usage date
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
@@ -673,10 +673,10 @@ pub struct RecordFailedChargeAttemptResponse {
     #[prost(message, optional, tag = "3")]
     pub next_payment_attempt: ::core::option::Option<::prost_types::Timestamp>,
 }
-#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct RetryChargeRequest {
-    #[prost(uint64, tag = "1")]
-    pub invoice_id: u64,
+    #[prost(string, tag = "1")]
+    pub invoice_guid: ::prost::alloc::string::String,
 }
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct RetryChargeResponse {

--- a/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
@@ -673,15 +673,15 @@ pub struct RecordFailedChargeAttemptResponse {
     #[prost(message, optional, tag = "3")]
     pub next_payment_attempt: ::core::option::Option<::prost_types::Timestamp>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct RetryChargeRequest {
-    #[prost(message, optional, tag = "1")]
-    pub invoice: ::core::option::Option<Invoice>,
+    #[prost(uint64, tag = "1")]
+    pub invoice_id: u64,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct RetryChargeResponse {
-    #[prost(message, optional, tag = "1")]
-    pub invoice: ::core::option::Option<Invoice>,
+    #[prost(bool, tag = "1")]
+    pub updated: bool,
 }
 /// Creates a new contract for a new billing period. Closes out the current contract by
 /// creating an invoice and setting the last usage date


### PR DESCRIPTION
This endpoint will allow us to mark an invoice as `needs_charged=True` and `next_payment_attempt=now` so we can port the admin payment retry endpoint to the billing platform. 