### PR TITLE
chore(billing-platform): Add protos for set_pending_tax_transaction endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.30.1"
+version = "0.31.2"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_set_pending_tax_transaction.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_set_pending_tax_transaction.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package sentry_protos.billing.v1.services.contract.v1;
+
+// Records the tax provider's document reference on an invoice as a pending tax
+// transaction, linking the invoice to the opened tax document so it can be
+// committed or voided once the charge outcome is known.
+message SetPendingTaxTransactionRequest {
+  uint64 invoice_id = 1;
+  // The tax provider's reference for the opened (uncommitted) tax document.
+  string external_reference = 2;
+}
+
+message SetPendingTaxTransactionResponse {
+  // True if a matching invoice was found and updated.
+  bool updated = 1;
+}

--- a/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
@@ -711,3 +711,20 @@ pub struct RolloverContractResponse {
     #[prost(uint64, tag = "3")]
     pub amount_billed: u64,
 }
+/// Records the tax provider's document reference on an invoice as a pending tax
+/// transaction, linking the invoice to the opened tax document so it can be
+/// committed or voided once the charge outcome is known.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct SetPendingTaxTransactionRequest {
+    #[prost(uint64, tag = "1")]
+    pub invoice_id: u64,
+    /// The tax provider's reference for the opened (uncommitted) tax document.
+    #[prost(string, tag = "2")]
+    pub external_reference: ::prost::alloc::string::String,
+}
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct SetPendingTaxTransactionResponse {
+    /// True if a matching invoice was found and updated.
+    #[prost(bool, tag = "1")]
+    pub updated: bool,
+}


### PR DESCRIPTION
Adds the `SetPendingTaxTransaction` request/response messages to the contract service for the PR https://github.com/getsentry/getsentry/pull/20624.

`SetPendingTaxTransactionRequest` carries the `invoice_id` and the tax provider's `external_reference`; `SetPendingTaxTransactionResponse` returns whether a matching invoice was updated. These back the getsentry contract service's `set_pending_tax_transaction`, which records the provider-side tax document reference on an invoice as a pending tax transaction so it can be committed or voided once the charge outcome is known. That method is currently prototyped with proto-free dataclasses (the dataclass-prototype pattern); these messages are what it migrates to.

Message-only and consistent with the other contract endpoints — `uint64 invoice_id`, bare `string`, one `endpoint_*.proto` for the pair, mirroring `MarkInvoicePaid`. Generated stubs are produced at build time, so only the `.proto` source is included here.
