### PR TITLE
feat(snuba): Opt-in ordering for TraceItemAttributeNames (order_by + response count)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.30.1"
+version = "0.31.2"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/snuba/v1/endpoint_trace_item_attributes.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_trace_item_attributes.proto
@@ -13,6 +13,33 @@ import "sentry_protos/snuba/v1/trace_item_filter.proto";
 // TraceItem are things like: span, error, log, replay
 // TraceItemAttributes could be things like: sentry.duration,user_id cart_total, etc.
 message TraceItemAttributeNamesRequest {
+  // OrderBy controls how the returned attribute names are ordered.
+  //
+  // When `order_by` is not set on the request, attribute names are returned
+  // in alphabetical (ascending by name) order. This is the historical default
+  // and is preserved for callers that predate this field.
+  message OrderBy {
+    // Column identifies which property of an attribute to order by.
+    enum Column {
+      // Defaults to ordering by COLUMN_NAME (alphabetical). This keeps the
+      // behaviour backwards compatible when `order_by` is left unset.
+      COLUMN_UNSPECIFIED = 0;
+      // Order by the attribute name (alphabetical).
+      COLUMN_NAME = 1;
+      // Order by how frequently the attribute occurs across the matched trace
+      // items (its count).
+      COLUMN_COUNT = 2;
+    }
+
+    // The column to order the returned attribute names by.
+    Column column = 1;
+
+    // When true, results are returned in descending order. Defaults to
+    // ascending. For example, to order by frequency with the most common
+    // attributes first, set `column = COLUMN_COUNT` and `descending = true`.
+    bool descending = 2;
+  }
+
   // metadata about the request
   // this is where you specify organization, project, time range etc.
   RequestMeta meta = 1;
@@ -38,6 +65,12 @@ message TraceItemAttributeNamesRequest {
   // This is a BEST-EFFORT operation. If no co-occurring keys are found within
   // 1 second, the endpoint returns without taking the intersecing attributes into account
   TraceItemFilter intersecting_attributes_filter = 8;
+
+  // optional, controls how the returned attribute names are ordered.
+  // When unset, names are returned alphabetically (ascending), which preserves
+  // the historical default for existing callers. Set this to opt in to a
+  // different ordering, e.g. by attribute frequency.
+  OrderBy order_by = 9;
 }
 
 // TraceItemAttributeNamesResponse is the response returned by the TraceItemAttributeNames endpoint.

--- a/proto/sentry_protos/snuba/v1/endpoint_trace_item_attributes.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_trace_item_attributes.proto
@@ -79,6 +79,12 @@ message TraceItemAttributeNamesResponse {
   message Attribute {
     string name = 1;
     AttributeKey.Type type = 2;
+
+    // optional, how frequently this attribute occurs across the matched trace
+    // items. Only populated when the request opts in to count ordering
+    // (order_by.column = COLUMN_COUNT); unset otherwise. The presence of this
+    // field distinguishes "not computed" from a genuine count of zero.
+    optional uint64 count = 3;
   }
   // all attributes that matched the filters in the request
   repeated Attribute attributes = 1;

--- a/proto/sentry_protos/snuba/v1/endpoint_trace_item_attributes.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_trace_item_attributes.proto
@@ -103,6 +103,34 @@ message TraceItemAttributeNamesResponse {
 // This endpoint only supports string values, it does not make sense
 // to get all the possible values of a numerical attribute
 message TraceItemAttributeValuesRequest {
+  // OrderBy controls how the returned values are ordered.
+  //
+  // When `order_by` is not set on the request, values are returned in
+  // alphabetical (ascending) order. This is the historical default and is
+  // preserved for callers that predate this field.
+  message OrderBy {
+    // Column identifies which property of a value to order by.
+    enum Column {
+      // Defaults to ordering by COLUMN_VALUE (alphabetical). This keeps the
+      // behaviour backwards compatible when `order_by` is left unset.
+      COLUMN_UNSPECIFIED = 0;
+      // Order by the value itself (alphabetical).
+      COLUMN_VALUE = 1;
+      // Order by how frequently the value occurs across the matched trace
+      // items (its count). The counts are returned in the response's `counts`
+      // field.
+      COLUMN_COUNT = 2;
+    }
+
+    // The column to order the returned values by.
+    Column column = 1;
+
+    // When true, results are returned in descending order. Defaults to
+    // ascending. For example, to order by frequency with the most common
+    // values first, set `column = COLUMN_COUNT` and `descending = true`.
+    bool descending = 2;
+  }
+
   // metadata about the request
   // this is where you specify organization, project, time range etc.
   RequestMeta meta = 1;
@@ -123,6 +151,13 @@ message TraceItemAttributeValuesRequest {
 
   // optional, used for pagination, the next page token will be returned in the response
   PageToken page_token = 6;
+
+  // optional, controls how the returned values are ordered.
+  // When unset, values are returned alphabetically (ascending), which
+  // preserves the historical default for existing callers. Set this to opt in
+  // to a different ordering, e.g. by value frequency (the response already
+  // returns the corresponding `counts`).
+  OrderBy order_by = 7;
 }
 
 // TraceItemAttributeValuesResponse is a response from the TraceItemAttributeValues endpoint

--- a/py/tests/test_snuba_v1.py
+++ b/py/tests/test_snuba_v1.py
@@ -740,9 +740,16 @@ def test_example_attribute_names_request_ordered_by_count() -> None:
         ),
     )
 
+    # when ordering by count, the response can include the per-attribute count
     response = TraceItemAttributeNamesResponse(
-        attributes=[TraceItemAttributeNamesResponse.Attribute(name="foo", type=AttributeKey.Type.TYPE_STRING)]
+        attributes=[
+            TraceItemAttributeNamesResponse.Attribute(
+                name="foo", type=AttributeKey.Type.TYPE_STRING, count=42
+            )
+        ]
     )
+    assert response.attributes[0].HasField("count")
+    assert response.attributes[0].count == 42
 
 
 def test_example_time_series_cross_item_query() -> None:

--- a/py/tests/test_snuba_v1.py
+++ b/py/tests/test_snuba_v1.py
@@ -752,6 +752,29 @@ def test_example_attribute_names_request_ordered_by_count() -> None:
     assert response.attributes[0].count == 42
 
 
+def test_example_attribute_values_request_ordered_by_count() -> None:
+    # Opt in to ordering attribute values by how frequently they occur,
+    # most common first. Leaving `order_by` unset preserves the default
+    # alphabetical (ascending) ordering.
+    request = TraceItemAttributeValuesRequest(
+        meta=COMMON_META,
+        key=AttributeKey(type=AttributeKey.TYPE_STRING, name="sentry.browser.name"),
+        limit=100,
+        order_by=TraceItemAttributeValuesRequest.OrderBy(
+            column=TraceItemAttributeValuesRequest.OrderBy.COLUMN_COUNT,
+            descending=True,
+        ),
+    )
+
+    # the values response already returns counts aligned with values
+    response = TraceItemAttributeValuesResponse(
+        values=["chrome", "safari"],
+        counts=[100, 25],
+    )
+    assert list(response.values) == ["chrome", "safari"]
+    assert list(response.counts) == [100, 25]
+
+
 def test_example_time_series_cross_item_query() -> None:
     """
     Find the number of spans with http.client over time in traces containing a span with op = 'db' that also contain errors with message = 'timeout'

--- a/py/tests/test_snuba_v1.py
+++ b/py/tests/test_snuba_v1.py
@@ -726,6 +726,25 @@ def test_example_attribute_names_request() -> None:
     )
 
 
+def test_example_attribute_names_request_ordered_by_count() -> None:
+    # Opt in to ordering attribute names by how frequently they occur,
+    # most common first. Leaving `order_by` unset preserves the default
+    # alphabetical (ascending) ordering.
+    request = TraceItemAttributeNamesRequest(
+        meta=COMMON_META,
+        limit=100,
+        type=AttributeKey.Type.TYPE_STRING,
+        order_by=TraceItemAttributeNamesRequest.OrderBy(
+            column=TraceItemAttributeNamesRequest.OrderBy.COLUMN_COUNT,
+            descending=True,
+        ),
+    )
+
+    response = TraceItemAttributeNamesResponse(
+        attributes=[TraceItemAttributeNamesResponse.Attribute(name="foo", type=AttributeKey.Type.TYPE_STRING)]
+    )
+
+
 def test_example_time_series_cross_item_query() -> None:
     """
     Find the number of spans with http.client over time in traces containing a span with op = 'db' that also contain errors with message = 'timeout'

--- a/rust/src/sentry_protos.snuba.v1.rs
+++ b/rust/src/sentry_protos.snuba.v1.rs
@@ -1673,6 +1673,79 @@ pub struct TraceItemAttributeNamesRequest {
     /// 1 second, the endpoint returns without taking the intersecing attributes into account
     #[prost(message, optional, tag = "8")]
     pub intersecting_attributes_filter: ::core::option::Option<TraceItemFilter>,
+    /// optional, controls how the returned attribute names are ordered.
+    /// When unset, names are returned alphabetically (ascending), which preserves
+    /// the historical default for existing callers. Set this to opt in to a
+    /// different ordering, e.g. by attribute frequency.
+    #[prost(message, optional, tag = "9")]
+    pub order_by: ::core::option::Option<trace_item_attribute_names_request::OrderBy>,
+}
+/// Nested message and enum types in `TraceItemAttributeNamesRequest`.
+pub mod trace_item_attribute_names_request {
+    /// OrderBy controls how the returned attribute names are ordered.
+    ///
+    /// When `order_by` is not set on the request, attribute names are returned
+    /// in alphabetical (ascending by name) order. This is the historical default
+    /// and is preserved for callers that predate this field.
+    #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+    pub struct OrderBy {
+        /// The column to order the returned attribute names by.
+        #[prost(enumeration = "order_by::Column", tag = "1")]
+        pub column: i32,
+        /// When true, results are returned in descending order. Defaults to
+        /// ascending. For example, to order by frequency with the most common
+        /// attributes first, set `column = COLUMN_COUNT` and `descending = true`.
+        #[prost(bool, tag = "2")]
+        pub descending: bool,
+    }
+    /// Nested message and enum types in `OrderBy`.
+    pub mod order_by {
+        /// Column identifies which property of an attribute to order by.
+        #[derive(
+            Clone,
+            Copy,
+            Debug,
+            PartialEq,
+            Eq,
+            Hash,
+            PartialOrd,
+            Ord,
+            ::prost::Enumeration
+        )]
+        #[repr(i32)]
+        pub enum Column {
+            /// Defaults to ordering by COLUMN_NAME (alphabetical). This keeps the
+            /// behaviour backwards compatible when `order_by` is left unset.
+            Unspecified = 0,
+            /// Order by the attribute name (alphabetical).
+            Name = 1,
+            /// Order by how frequently the attribute occurs across the matched trace
+            /// items (its count).
+            Count = 2,
+        }
+        impl Column {
+            /// String value of the enum field names used in the ProtoBuf definition.
+            ///
+            /// The values are not transformed in any way and thus are considered stable
+            /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+            pub fn as_str_name(&self) -> &'static str {
+                match self {
+                    Self::Unspecified => "COLUMN_UNSPECIFIED",
+                    Self::Name => "COLUMN_NAME",
+                    Self::Count => "COLUMN_COUNT",
+                }
+            }
+            /// Creates an enum from field names used in the ProtoBuf definition.
+            pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+                match value {
+                    "COLUMN_UNSPECIFIED" => Some(Self::Unspecified),
+                    "COLUMN_NAME" => Some(Self::Name),
+                    "COLUMN_COUNT" => Some(Self::Count),
+                    _ => None,
+                }
+            }
+        }
+    }
 }
 /// TraceItemAttributeNamesResponse is the response returned by the TraceItemAttributeNames endpoint.
 /// It is the counterpart to TraceItemAttributeNamesRequest.

--- a/rust/src/sentry_protos.snuba.v1.rs
+++ b/rust/src/sentry_protos.snuba.v1.rs
@@ -1809,6 +1809,81 @@ pub struct TraceItemAttributeValuesRequest {
     /// optional, used for pagination, the next page token will be returned in the response
     #[prost(message, optional, tag = "6")]
     pub page_token: ::core::option::Option<PageToken>,
+    /// optional, controls how the returned values are ordered.
+    /// When unset, values are returned alphabetically (ascending), which
+    /// preserves the historical default for existing callers. Set this to opt in
+    /// to a different ordering, e.g. by value frequency (the response already
+    /// returns the corresponding `counts`).
+    #[prost(message, optional, tag = "7")]
+    pub order_by: ::core::option::Option<trace_item_attribute_values_request::OrderBy>,
+}
+/// Nested message and enum types in `TraceItemAttributeValuesRequest`.
+pub mod trace_item_attribute_values_request {
+    /// OrderBy controls how the returned values are ordered.
+    ///
+    /// When `order_by` is not set on the request, values are returned in
+    /// alphabetical (ascending) order. This is the historical default and is
+    /// preserved for callers that predate this field.
+    #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+    pub struct OrderBy {
+        /// The column to order the returned values by.
+        #[prost(enumeration = "order_by::Column", tag = "1")]
+        pub column: i32,
+        /// When true, results are returned in descending order. Defaults to
+        /// ascending. For example, to order by frequency with the most common
+        /// values first, set `column = COLUMN_COUNT` and `descending = true`.
+        #[prost(bool, tag = "2")]
+        pub descending: bool,
+    }
+    /// Nested message and enum types in `OrderBy`.
+    pub mod order_by {
+        /// Column identifies which property of a value to order by.
+        #[derive(
+            Clone,
+            Copy,
+            Debug,
+            PartialEq,
+            Eq,
+            Hash,
+            PartialOrd,
+            Ord,
+            ::prost::Enumeration
+        )]
+        #[repr(i32)]
+        pub enum Column {
+            /// Defaults to ordering by COLUMN_VALUE (alphabetical). This keeps the
+            /// behaviour backwards compatible when `order_by` is left unset.
+            Unspecified = 0,
+            /// Order by the value itself (alphabetical).
+            Value = 1,
+            /// Order by how frequently the value occurs across the matched trace
+            /// items (its count). The counts are returned in the response's `counts`
+            /// field.
+            Count = 2,
+        }
+        impl Column {
+            /// String value of the enum field names used in the ProtoBuf definition.
+            ///
+            /// The values are not transformed in any way and thus are considered stable
+            /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+            pub fn as_str_name(&self) -> &'static str {
+                match self {
+                    Self::Unspecified => "COLUMN_UNSPECIFIED",
+                    Self::Value => "COLUMN_VALUE",
+                    Self::Count => "COLUMN_COUNT",
+                }
+            }
+            /// Creates an enum from field names used in the ProtoBuf definition.
+            pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+                match value {
+                    "COLUMN_UNSPECIFIED" => Some(Self::Unspecified),
+                    "COLUMN_VALUE" => Some(Self::Value),
+                    "COLUMN_COUNT" => Some(Self::Count),
+                    _ => None,
+                }
+            }
+        }
+    }
 }
 /// TraceItemAttributeValuesResponse is a response from the TraceItemAttributeValues endpoint
 /// it is the counterpart to TraceItemAttributesRequest

--- a/rust/src/sentry_protos.snuba.v1.rs
+++ b/rust/src/sentry_protos.snuba.v1.rs
@@ -1771,6 +1771,12 @@ pub mod trace_item_attribute_names_response {
         pub name: ::prost::alloc::string::String,
         #[prost(enumeration = "super::attribute_key::Type", tag = "2")]
         pub r#type: i32,
+        /// optional, how frequently this attribute occurs across the matched trace
+        /// items. Only populated when the request opts in to count ordering
+        /// (order_by.column = COLUMN_COUNT); unset otherwise. The presence of this
+        /// field distinguishes "not computed" from a genuine count of zero.
+        #[prost(uint64, optional, tag = "3")]
+        pub count: ::core::option::Option<u64>,
     }
 }
 /// TraceItemAttributeValuesRequest is a request to the TraceItemAttributeValues endpoint,


### PR DESCRIPTION
## Summary

Adds **opt-in ordering** to the `TraceItemAttributeNames` endpoint so callers can sort returned attribute names by frequency, while existing consumers keep their current alphabetical behavior. This is the proto half of supporting a `sort:-count()` UX without changing the default for anyone.

Two additive, backwards-compatible changes to `endpoint_trace_item_attributes.proto`:

1. **`TraceItemAttributeNamesRequest.order_by`** (field 9) — a nested `OrderBy { Column column; bool descending; }` message. `Column` is `COLUMN_NAME` (default, alphabetical) or `COLUMN_COUNT`. When `order_by` is unset the endpoint keeps its historical alphabetical (ascending by name) ordering, so existing callers are unaffected. `sort:-count()` maps to `column=COLUMN_COUNT, descending=true`.

2. **`TraceItemAttributeNamesResponse.Attribute.count`** (field 3) — an `optional uint64` returning how frequently each attribute occurs. Uses proto3 presence so a genuine count of zero is distinguishable from "not computed"; only populated when the caller opts in to count ordering.

### Why this shape
The nested `OrderBy { <key>; bool descending; }` mirrors the existing convention in this package (`GetTracesRequest`, `TraceItemTableRequest`), and is strictly more expressive than the flat `TraceOrderBy` enum used by `find_traces` — it supports name/count × asc/desc rather than baking direction into enum values.

## Rollout sequence
1. Land + release this proto change.
2. Bump `sentry-protos` in snuba and wire the endpoint to read `order_by`: unset / `COLUMN_NAME` keeps the current alphabetical query; `COLUMN_COUNT` switches to the `count()` / `groupby` / `count DESC` query (and populates `Attribute.count`).
3. sentry's frontend opts in (`sort:-count()`) only where it wants frequency ordering.

## Testing
- `buf lint`, `buf format`, and `buf breaking` against `main` all pass (additive, non-breaking).
- Regenerated the committed Rust bindings; `cargo check` and `cargo clippy -- -D warnings` pass.
- `pytest py/tests/test_snuba_v1.py` passes, including a new example exercising `order_by` and the response `count`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gj3B9xDfGP21qqggeUzTDe)_