### PR TITLE
ref: Add supports on demand

### DIFF
--- a/proto/sentry_protos/billing/v1/services/contract/v1/billing_config.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/billing_config.proto
@@ -61,4 +61,9 @@ message BillingConfig {
   // The number-of-months interval the contract was signed under
   // (1 = monthly, 12 = annual). Frozen for the life of the contract.
   uint32 month_interval = 7;
+
+  // Whether the org is allowed to incur pay-as-you-go usage.
+  // Credit-card orgs always support payg; invoiced orgs that should
+  // support it are an explicit override.
+  bool supports_payg = 8;
 }


### PR DESCRIPTION
Not all contracts support on demand. Credit card + an override for enterprise do, we can abstract that implementation to just the contract service and check a boolean flag like this everywhere else