### PR TITLE
chore(billing-platform): carry tax_transaction_code on contract create/rollover requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.32.3"
+version = "0.32.4"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_create_contract.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_create_contract.proto
@@ -25,6 +25,12 @@ message CreateContractRequest {
   // Whether usage past reserved volume is allowed (and billed) instead of
   // hard-stopping ingestion.
   bool has_soft_cap = 8;
+
+  // The tax provider's reference for the tax document opened for this invoice.
+  // When set, the contract service records it on the created invoice as a
+  // pending tax transaction atomically with invoice creation. Unset means no
+  // tax document was opened.
+  optional string tax_transaction_code = 9;
 }
 
 message CreateContractResponse {

--- a/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_rollover_contract.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_rollover_contract.proto
@@ -18,6 +18,12 @@ message RolloverContractRequest {
   // The pending change to apply to the new contract, if any. Unset means no
   // pending change is being applied during this rollover.
   optional sentry_protos.billing.v1.common.v1.PendingChange pending_change = 5;
+
+  // The tax provider's reference for the tax document opened for this invoice.
+  // When set, the contract service records it on the new invoice as a pending
+  // tax transaction atomically with invoice creation, so the document can later
+  // be committed or voided. Unset means no tax document was opened.
+  optional string tax_transaction_code = 7;
 }
 
 message RolloverContractResponse {

--- a/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
@@ -520,6 +520,12 @@ pub struct CreateContractRequest {
     /// hard-stopping ingestion.
     #[prost(bool, tag = "8")]
     pub has_soft_cap: bool,
+    /// The tax provider's reference for the tax document opened for this invoice.
+    /// When set, the contract service records it on the created invoice as a
+    /// pending tax transaction atomically with invoice creation. Unset means no
+    /// tax document was opened.
+    #[prost(string, optional, tag = "9")]
+    pub tax_transaction_code: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct CreateContractResponse {
@@ -722,6 +728,12 @@ pub struct RolloverContractRequest {
     pub pending_change: ::core::option::Option<
         super::super::super::common::v1::PendingChange,
     >,
+    /// The tax provider's reference for the tax document opened for this invoice.
+    /// When set, the contract service records it on the new invoice as a pending
+    /// tax transaction atomically with invoice creation, so the document can later
+    /// be committed or voided. Unset means no tax document was opened.
+    #[prost(string, optional, tag = "7")]
+    pub tax_transaction_code: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct RolloverContractResponse {


### PR DESCRIPTION
This is for PR https://github.com/getsentry/getsentry/pull/20624

Adds an optional `tax_transaction_code` (field 7) to `CreateContractRequest` and `RolloverContractRequest`.

This backs getsentry's **atomic tax-linkage**: today the platform persists the invoice and then writes the tax document's reference in a *separate* best-effort call (`set_pending_tax_transaction`), which can fail and leave a charged invoice with no linked tax document — collected-but-unremitted tax with no automated recovery. Carrying the reference in the create/rollover request lets the contract service write it in the **same insert** as the invoice amount, removing that window (mirroring how legacy billing links the code atomically in its `Invoice.objects.create`).

Field 7 leaves rollover field 6 free for the independent `tax_pending` flag (PR #287). Message-only; the generated Rust stub is regenerated here, Python stubs build at package time. Supersedes #315 (the standalone `set_pending` endpoint protos), which getsentry's atomic linkage removes.