### PR TITLE
chore(billing-platform): Add clear_user_parameter to PendingChange

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/common/v1/pending_change.proto
+++ b/proto/sentry_protos/billing/v1/common/v1/pending_change.proto
@@ -52,6 +52,8 @@ message PendingUserConfig {
 
 message PAYGBudget {
   uint64 budget_cents = 1;
+  // Whether the next billing cycle should clear the Contract's existing UserParameter
+  bool clear_user_parameter = 2;
 }
 
 message Reservation {
@@ -60,6 +62,8 @@ message Reservation {
     bool is_unlimited = 2;
     uint64 num_reserved_units = 3;
   }
+  // Whether the next billing cycle should clear the Contract's existing UserParameter
+  bool clear_user_parameter = 4;
 }
 
 message LineItemUids {

--- a/rust/src/sentry_protos.billing.v1.common.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.common.v1.rs
@@ -323,11 +323,17 @@ pub mod pending_user_config {
 pub struct PaygBudget {
     #[prost(uint64, tag = "1")]
     pub budget_cents: u64,
+    /// Whether the next billing cycle should clear the Contract's existing UserParameter
+    #[prost(bool, tag = "2")]
+    pub clear_user_parameter: bool,
 }
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Reservation {
     #[prost(uint64, tag = "1")]
     pub reserved_price_cents: u64,
+    /// Whether the next billing cycle should clear the Contract's existing UserParameter
+    #[prost(bool, tag = "4")]
+    pub clear_user_parameter: bool,
     #[prost(oneof = "reservation::ReservedUnits", tags = "2, 3")]
     pub reserved_units: ::core::option::Option<reservation::ReservedUnits>,
 }


### PR DESCRIPTION
Allows us to clear UserParameters that are downgraded to the package's default volume OR when a package change occurs and a particular line item is not available on the new package (ie transactions or spans).