### PR TITLE
ref: Add protos fields for customer subscription API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.32.0"
+version = "0.32.2"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/services/contract/v1/billing_config.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/billing_config.proto
@@ -66,4 +66,12 @@ message BillingConfig {
   // Credit-card orgs always support payg; invoiced orgs that should
   // support it are an explicit override.
   bool supports_payg = 8;
+
+  // Whether this is a managed (sales-assisted) subscription rather than
+  // self-serve.
+  bool is_managed = 9;
+
+  // Whether the org has a soft cap: usage past reserved volume is allowed
+  // (and billed) instead of hard-stopping ingestion.
+  bool has_soft_cap = 10;
 }

--- a/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_create_contract.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_create_contract.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package sentry_protos.billing.v1.services.contract.v1;
 
 import "sentry_protos/billing/v1/common/v1/address.proto";
+import "sentry_protos/billing/v1/services/contract/v1/billing_config.proto";
 import "sentry_protos/billing/v1/services/contract/v1/invoice.proto";
 import "sentry_protos/billing/v1/services/contract/v1/pricing_config.proto";
 
@@ -16,6 +17,14 @@ message CreateContractRequest {
   // supported_month_intervals. If unset, defaults to the package's first
   // supported interval.
   uint32 month_interval = 6;
+
+  // How the contract is billed. If unset (BILLING_TYPE_UNSPECIFIED), the
+  // contract defaults to credit-card.
+  BillingType billing_type = 7;
+
+  // Whether usage past reserved volume is allowed (and billed) instead of
+  // hard-stopping ingestion.
+  bool has_soft_cap = 8;
 }
 
 message CreateContractResponse {

--- a/proto/sentry_protos/billing/v1/services/package/v1/package.proto
+++ b/proto/sentry_protos/billing/v1/services/package/v1/package.proto
@@ -70,4 +70,11 @@ message PackageConfig {
 
   // Title shown in admin interfaces, not customer-facing.
   string admin_title = 9;
+
+  // Whether the package is treated as enterprise in the UI (display name,
+  // upsell suppression).
+  bool is_enterprise = 10;
+
+  // Whether the package can be chosen in the self-serve checkout flow.
+  bool user_selectable = 11;
 }

--- a/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
@@ -50,6 +50,19 @@ pub struct BillingConfig {
     /// (1 = monthly, 12 = annual). Frozen for the life of the contract.
     #[prost(uint32, tag = "7")]
     pub month_interval: u32,
+    /// Whether the org is allowed to incur pay-as-you-go usage.
+    /// Credit-card orgs always support payg; invoiced orgs that should
+    /// support it are an explicit override.
+    #[prost(bool, tag = "8")]
+    pub supports_payg: bool,
+    /// Whether this is a managed (sales-assisted) subscription rather than
+    /// self-serve.
+    #[prost(bool, tag = "9")]
+    pub is_managed: bool,
+    /// Whether the org has a soft cap: usage past reserved volume is allowed
+    /// (and billed) instead of hard-stopping ingestion.
+    #[prost(bool, tag = "10")]
+    pub has_soft_cap: bool,
 }
 /// Indicates how the account is billed.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -499,6 +512,14 @@ pub struct CreateContractRequest {
     /// supported interval.
     #[prost(uint32, tag = "6")]
     pub month_interval: u32,
+    /// How the contract is billed. If unset (BILLING_TYPE_UNSPECIFIED), the
+    /// contract defaults to credit-card.
+    #[prost(enumeration = "BillingType", tag = "7")]
+    pub billing_type: i32,
+    /// Whether usage past reserved volume is allowed (and billed) instead of
+    /// hard-stopping ingestion.
+    #[prost(bool, tag = "8")]
+    pub has_soft_cap: bool,
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct CreateContractResponse {

--- a/rust/src/sentry_protos.billing.v1.services.package.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.package.v1.rs
@@ -116,6 +116,13 @@ pub struct PackageConfig {
     /// Title shown in admin interfaces, not customer-facing.
     #[prost(string, tag = "9")]
     pub admin_title: ::prost::alloc::string::String,
+    /// Whether the package is treated as enterprise in the UI (display name,
+    /// upsell suppression).
+    #[prost(bool, tag = "10")]
+    pub is_enterprise: bool,
+    /// Whether the package can be chosen in the self-serve checkout flow.
+    #[prost(bool, tag = "11")]
+    pub user_selectable: bool,
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct GetPackageRequest {


### PR DESCRIPTION
These fields will be needed as part of the customer details API