### PR TITLE
Add budget exhaustion field to UsagePricer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.32.2"
+version = "0.32.3"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/services/usage_pricer/v1/endpoint_usage_pricer.proto
+++ b/proto/sentry_protos/billing/v1/services/usage_pricer/v1/endpoint_usage_pricer.proto
@@ -45,8 +45,11 @@ message LineItemUsageSummary {
   // Net cents consumed by this line item in the billing period (after credits/trials applied).
   uint64 payg_spend_cents = 2;
 
-  // How much of the line item was consumed (in the line item's units)
+  // How much of the line item was consumed by PAYG (in the line item's units)
   uint64 quantity = 3;
+
+  // Whether the usage pricer had to cap the spend based on the budget set by the contract
+  bool payg_budget_exhausted = 4;
 }
 
 message SharedLineItemUsageSummary {
@@ -55,6 +58,9 @@ message SharedLineItemUsageSummary {
 
   // Line item breakdown within shared budget
   repeated LineItemUsageSummary line_item_summaries = 2;
+
+  // Whether the usage pricer had to cap the spend based on the budget set by the contract
+  bool payg_budget_exhausted = 3;
 }
 
 message UsagePricerResponse {

--- a/rust/src/sentry_protos.billing.v1.services.usage_pricer.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.usage_pricer.v1.rs
@@ -45,9 +45,12 @@ pub struct LineItemUsageSummary {
     /// Net cents consumed by this line item in the billing period (after credits/trials applied).
     #[prost(uint64, tag = "2")]
     pub payg_spend_cents: u64,
-    /// How much of the line item was consumed (in the line item's units)
+    /// How much of the line item was consumed by PAYG (in the line item's units)
     #[prost(uint64, tag = "3")]
     pub quantity: u64,
+    /// Whether the usage pricer had to cap the spend based on the budget set by the contract
+    #[prost(bool, tag = "4")]
+    pub payg_budget_exhausted: bool,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SharedLineItemUsageSummary {
@@ -57,6 +60,9 @@ pub struct SharedLineItemUsageSummary {
     /// Line item breakdown within shared budget
     #[prost(message, repeated, tag = "2")]
     pub line_item_summaries: ::prost::alloc::vec::Vec<LineItemUsageSummary>,
+    /// Whether the usage pricer had to cap the spend based on the budget set by the contract
+    #[prost(bool, tag = "3")]
+    pub payg_budget_exhausted: bool,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UsagePricerResponse {


### PR DESCRIPTION
The usage pricer already knows whether a PAYG budget has been exhausted. We don't charge customers over the budget that has been set. Expose this information so that we can leverage it in the quota enforcement