### PR TITLE
feat(snuba): Add conversation_id and session_id to TraceItem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.32.4"
+version = "0.32.5"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/snuba/v1/trace_item.proto
+++ b/proto/sentry_protos/snuba/v1/trace_item.proto
@@ -54,6 +54,11 @@ message TraceItem {
   double client_sample_rate = 8;
   double server_sample_rate = 9;
 
+  // The ID of the conversation this item belongs to, if any.
+  string conversation_id = 10;
+  // The ID of the session this item belongs to, if any.
+  string session_id = 11;
+
   // Internal fields
   uint32 retention_days = 100;
   google.protobuf.Timestamp received = 101;

--- a/rust/src/sentry_protos.snuba.v1.rs
+++ b/rust/src/sentry_protos.snuba.v1.rs
@@ -2520,6 +2520,12 @@ pub struct TraceItem {
     pub client_sample_rate: f64,
     #[prost(double, tag = "9")]
     pub server_sample_rate: f64,
+    /// The ID of the conversation this item belongs to, if any.
+    #[prost(string, tag = "10")]
+    pub conversation_id: ::prost::alloc::string::String,
+    /// The ID of the session this item belongs to, if any.
+    #[prost(string, tag = "11")]
+    pub session_id: ::prost::alloc::string::String,
     /// Internal fields
     #[prost(uint32, tag = "100")]
     pub retention_days: u32,


### PR DESCRIPTION
## Summary

Adds two new string fields to the `TraceItem` protobuf (`proto/sentry_protos/snuba/v1/trace_item.proto`):

- `conversation_id` (field `10`) — the ID of the conversation this item belongs to, if any.
- `session_id` (field `11`) — the ID of the session this item belongs to, if any.

These let trace items be associated with a conversation and a session.

## Details

- Both fields are `string`, consistent with the existing `trace_id` field.
- They use the next available tag numbers (`10`, `11`) in the public field range, so the change is purely additive and backwards compatible.
- Regenerated the Rust bindings (`rust/src/sentry_protos.snuba.v1.rs`). The Python bindings are gitignored, so they are not committed (they regenerate from the proto).
- `Cargo.lock` picked up an in-flight `0.32.4 → 0.32.5` version sync, matching the pattern of other recent feature PRs.
- `CHANGELOG.md` / `VERSION` are intentionally left untouched — those are bumped by the automated release process, not in feature PRs.

## Testing

- `make build-rust` (regenerates bindings; compiles cleanly via `cargo build`).
- `make build-py` (Python bindings generate successfully).
- Verified a serialize/parse round-trip of the new fields in Python.
- `pytest py/tests/test_snuba_v1.py` — all 14 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016oMzThA3hxjuciMrJU8AgF)_