### PR TITLE
chore(billing-platform): Add trial limits to package line items

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.32.5"
+version = "0.33.0"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/services/package/v1/package.proto
+++ b/proto/sentry_protos/billing/v1/services/package/v1/package.proto
@@ -26,6 +26,13 @@ message LineItemConfig {
 
   // Used for calculating spend that should not apply towards an organization's PAYG budget (ie Seer seats)
   sentry_protos.billing.v1.common.v1.TieredPricingRate uncapped_rate = 9;
+
+  // How many units are available for a PackageConfig during a subscription trial? For packages that are not eligible for trials,
+  // this field will be unset for all line items.
+  oneof trial_units {
+    bool is_unlimited_trial = 10;
+    uint64 num_trial_units = 11;
+  }
 }
 
 // Represents a budget included in a package that is collectively used by one or more line items,
@@ -51,6 +58,13 @@ message SharedLineItemPool {
   // Similar to LineItemConfig.reserved_rate, this field will hold the list of available reserved tiers for this line item
   // as well as the prices for each respective tier.
   sentry_protos.billing.v1.common.v1.TieredPricingRate reserved_tier = 8;
+
+  // How many units are available for a PackageConfig during a subscription trial? For packages that are not eligible for trials,
+  // this field will be unset for all line items.
+  oneof trial_units {
+    bool is_unlimited_trial = 9;
+    uint64 num_trial_units = 10;
+  }
 }
 
 message PackageConfig {

--- a/rust/src/sentry_protos.billing.v1.services.package.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.package.v1.rs
@@ -31,6 +31,10 @@ pub struct LineItemConfig {
     pub included_reserved_units: ::core::option::Option<
         line_item_config::IncludedReservedUnits,
     >,
+    /// How many units are available for a PackageConfig during a subscription trial? For packages that are not eligible for trials,
+    /// this field will be unset for all line items.
+    #[prost(oneof = "line_item_config::TrialUnits", tags = "10, 11")]
+    pub trial_units: ::core::option::Option<line_item_config::TrialUnits>,
 }
 /// Nested message and enum types in `LineItemConfig`.
 pub mod line_item_config {
@@ -42,6 +46,15 @@ pub mod line_item_config {
         /// the type communicates whether the line item is unlimited or not, additionally reserved budget line items have a non-zero reserved_rate in addition to 0 reserved_units
         #[prost(uint64, tag = "6")]
         NumReservedUnits(u64),
+    }
+    /// How many units are available for a PackageConfig during a subscription trial? For packages that are not eligible for trials,
+    /// this field will be unset for all line items.
+    #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Oneof)]
+    pub enum TrialUnits {
+        #[prost(bool, tag = "10")]
+        IsUnlimitedTrial(bool),
+        #[prost(uint64, tag = "11")]
+        NumTrialUnits(u64),
     }
 }
 /// Represents a budget included in a package that is collectively used by one or more line items,
@@ -86,6 +99,22 @@ pub struct SharedLineItemPool {
     pub reserved_tier: ::core::option::Option<
         super::super::super::common::v1::TieredPricingRate,
     >,
+    /// How many units are available for a PackageConfig during a subscription trial? For packages that are not eligible for trials,
+    /// this field will be unset for all line items.
+    #[prost(oneof = "shared_line_item_pool::TrialUnits", tags = "9, 10")]
+    pub trial_units: ::core::option::Option<shared_line_item_pool::TrialUnits>,
+}
+/// Nested message and enum types in `SharedLineItemPool`.
+pub mod shared_line_item_pool {
+    /// How many units are available for a PackageConfig during a subscription trial? For packages that are not eligible for trials,
+    /// this field will be unset for all line items.
+    #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Oneof)]
+    pub enum TrialUnits {
+        #[prost(bool, tag = "9")]
+        IsUnlimitedTrial(bool),
+        #[prost(uint64, tag = "10")]
+        NumTrialUnits(u64),
+    }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PackageConfig {


### PR DESCRIPTION
Define trial config amounts in packages. This will be used by the Engagement service to validate that a package is eligible to be used for subscription trials and to provide TrialConfigs to the create_trial API.