### PR TITLE
Add allow_payg field to PackageConfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.32.5"
+version = "0.33.0"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/services/package/v1/package.proto
+++ b/proto/sentry_protos/billing/v1/services/package/v1/package.proto
@@ -78,6 +78,6 @@ message PackageConfig {
   // Whether the package can be chosen in the self-serve checkout flow.
   bool user_selectable = 11;
 
-  // Whether the package allows pay-as-you-go (PAYG) billing.
-  bool allow_payg = 12;
+  // Whether the package has pay-as-you-go (PAYG) modes.
+  bool has_payg_modes = 12;
 }

--- a/proto/sentry_protos/billing/v1/services/package/v1/package.proto
+++ b/proto/sentry_protos/billing/v1/services/package/v1/package.proto
@@ -77,4 +77,7 @@ message PackageConfig {
 
   // Whether the package can be chosen in the self-serve checkout flow.
   bool user_selectable = 11;
+
+  // Whether the package allows pay-as-you-go (PAYG) billing.
+  bool allow_payg = 12;
 }

--- a/rust/src/sentry_protos.billing.v1.services.package.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.package.v1.rs
@@ -123,6 +123,9 @@ pub struct PackageConfig {
     /// Whether the package can be chosen in the self-serve checkout flow.
     #[prost(bool, tag = "11")]
     pub user_selectable: bool,
+    /// Whether the package allows pay-as-you-go (PAYG) billing.
+    #[prost(bool, tag = "12")]
+    pub allow_payg: bool,
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct GetPackageRequest {

--- a/rust/src/sentry_protos.billing.v1.services.package.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.package.v1.rs
@@ -123,9 +123,9 @@ pub struct PackageConfig {
     /// Whether the package can be chosen in the self-serve checkout flow.
     #[prost(bool, tag = "11")]
     pub user_selectable: bool,
-    /// Whether the package allows pay-as-you-go (PAYG) billing.
+    /// Whether the package has pay-as-you-go (PAYG) modes.
     #[prost(bool, tag = "12")]
-    pub allow_payg: bool,
+    pub has_payg_modes: bool,
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct GetPackageRequest {


### PR DESCRIPTION
Add a boolean field indicating whether a package permits pay-as-you-go (PAYG) billing, so consumers can gate PAYG behavior per package.