### PR TITLE
docs(usage_pricer): Clarify payg_budget_exhausted semantics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/services/usage_pricer/v1/endpoint_usage_pricer.proto
+++ b/proto/sentry_protos/billing/v1/services/usage_pricer/v1/endpoint_usage_pricer.proto
@@ -48,8 +48,12 @@ message LineItemUsageSummary {
   // How much of the line item was consumed by PAYG (in the line item's units)
   uint64 quantity = 3;
 
-  // Whether the contract PAYG budget for this line item's cap scope has no budget
-  // remaining (pre-cap spend >= cap, or any spend when the cap is 0).
+  // Whether the contract PAYG budget covering this line item has no budget remaining.
+  // "No budget remaining" means the pre-cap spend within the budget's scope reaches the
+  // cap (>=), or there is any spend when the cap is 0. For a shared (all-items) budget the
+  // comparison uses the pooled pre-cap spend, so a line item can be flagged exhausted even
+  // when its own spend is small. Always false for items priced at an uncapped rate (e.g.
+  // Seer) and for items with no configured cap, since neither counts against a PAYG budget.
   bool payg_budget_exhausted = 4;
 }
 
@@ -60,8 +64,8 @@ message SharedLineItemUsageSummary {
   // Line item breakdown within shared budget
   repeated LineItemUsageSummary line_item_summaries = 2;
 
-  // Whether the shared PAYG budget has no budget remaining (any member line item in the
-  // pool is exhausted).
+  // Whether the shared PAYG budget has no budget remaining, i.e. any member line item in
+  // the pool is exhausted (see LineItemUsageSummary.payg_budget_exhausted).
   bool payg_budget_exhausted = 3;
 }
 

--- a/proto/sentry_protos/billing/v1/services/usage_pricer/v1/endpoint_usage_pricer.proto
+++ b/proto/sentry_protos/billing/v1/services/usage_pricer/v1/endpoint_usage_pricer.proto
@@ -48,7 +48,8 @@ message LineItemUsageSummary {
   // How much of the line item was consumed by PAYG (in the line item's units)
   uint64 quantity = 3;
 
-  // Whether the usage pricer had to cap the spend based on the budget set by the contract
+  // Whether the contract PAYG budget for this line item's cap scope has no budget
+  // remaining (pre-cap spend >= cap, or any spend when the cap is 0).
   bool payg_budget_exhausted = 4;
 }
 
@@ -59,7 +60,8 @@ message SharedLineItemUsageSummary {
   // Line item breakdown within shared budget
   repeated LineItemUsageSummary line_item_summaries = 2;
 
-  // Whether the usage pricer had to cap the spend based on the budget set by the contract
+  // Whether the shared PAYG budget has no budget remaining (any member line item in the
+  // pool is exhausted).
   bool payg_budget_exhausted = 3;
 }
 

--- a/rust/src/sentry_protos.billing.v1.services.usage_pricer.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.usage_pricer.v1.rs
@@ -48,8 +48,12 @@ pub struct LineItemUsageSummary {
     /// How much of the line item was consumed by PAYG (in the line item's units)
     #[prost(uint64, tag = "3")]
     pub quantity: u64,
-    /// Whether the contract PAYG budget for this line item's cap scope has no budget
-    /// remaining (pre-cap spend >= cap, or any spend when the cap is 0).
+    /// Whether the contract PAYG budget covering this line item has no budget remaining.
+    /// "No budget remaining" means the pre-cap spend within the budget's scope reaches the
+    /// cap (>=), or there is any spend when the cap is 0. For a shared (all-items) budget the
+    /// comparison uses the pooled pre-cap spend, so a line item can be flagged exhausted even
+    /// when its own spend is small. Always false for items priced at an uncapped rate (e.g.
+    /// Seer) and for items with no configured cap, since neither counts against a PAYG budget.
     #[prost(bool, tag = "4")]
     pub payg_budget_exhausted: bool,
 }
@@ -61,8 +65,8 @@ pub struct SharedLineItemUsageSummary {
     /// Line item breakdown within shared budget
     #[prost(message, repeated, tag = "2")]
     pub line_item_summaries: ::prost::alloc::vec::Vec<LineItemUsageSummary>,
-    /// Whether the shared PAYG budget has no budget remaining (any member line item in the
-    /// pool is exhausted).
+    /// Whether the shared PAYG budget has no budget remaining, i.e. any member line item in
+    /// the pool is exhausted (see LineItemUsageSummary.payg_budget_exhausted).
     #[prost(bool, tag = "3")]
     pub payg_budget_exhausted: bool,
 }

--- a/rust/src/sentry_protos.billing.v1.services.usage_pricer.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.usage_pricer.v1.rs
@@ -48,7 +48,8 @@ pub struct LineItemUsageSummary {
     /// How much of the line item was consumed by PAYG (in the line item's units)
     #[prost(uint64, tag = "3")]
     pub quantity: u64,
-    /// Whether the usage pricer had to cap the spend based on the budget set by the contract
+    /// Whether the contract PAYG budget for this line item's cap scope has no budget
+    /// remaining (pre-cap spend >= cap, or any spend when the cap is 0).
     #[prost(bool, tag = "4")]
     pub payg_budget_exhausted: bool,
 }
@@ -60,7 +61,8 @@ pub struct SharedLineItemUsageSummary {
     /// Line item breakdown within shared budget
     #[prost(message, repeated, tag = "2")]
     pub line_item_summaries: ::prost::alloc::vec::Vec<LineItemUsageSummary>,
-    /// Whether the usage pricer had to cap the spend based on the budget set by the contract
+    /// Whether the shared PAYG budget has no budget remaining (any member line item in the
+    /// pool is exhausted).
     #[prost(bool, tag = "3")]
     pub payg_budget_exhausted: bool,
 }


### PR DESCRIPTION
Rewrites the `payg_budget_exhausted` doc comments on `LineItemUsageSummary` (field 4) and `SharedLineItemUsageSummary` (field 3) so consumers can reason about the flag without reading the getsentry producer. Comment-only; no wire-format change.

The old comment ("the usage pricer had to cap the spend") was misleading: the producer sets the flag whenever there is no budget left, even when no spend was actually reduced (pre-cap spend exactly equal to the cap). The field now documents the producer's real semantics:

- No budget remaining means pre-cap spend reaches the cap (`>=`), or there is any spend when the cap is `0`.
- For a shared (all-items) budget the comparison uses the **pooled** pre-cap spend, so a line item can be flagged exhausted even when its own spend is small.
- Always `false` for items priced at an uncapped rate (e.g. Seer) and for items with no configured cap, since neither counts against a PAYG budget.

The shared-summary comment now points at the line-item doc instead of restating the rule, so the two cannot drift.

The regenerated Rust binding carries the same doc text; review the `.proto` change and treat the `.rs` change as generated output.