### PR TITLE
ref(billing-platform): Split up monetary and unit grants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/services/engagement/v1/endpoint_create_grant.proto
+++ b/proto/sentry_protos/billing/v1/services/engagement/v1/endpoint_create_grant.proto
@@ -7,6 +7,7 @@ import "sentry_protos/billing/v1/services/engagement/v1/grant.proto";
 import "sentry_protos/billing/v1/services/engagement/v1/grant_source.proto";
 
 message CreateGrantRequest {
+  option deprecated = true;
   uint64 organization_id = 1;
 
   // Must be included when GrantType is UNITS
@@ -25,5 +26,6 @@ message CreateGrantRequest {
 }
 
 message CreateGrantResponse {
+  option deprecated = true;
   bool created = 1;
 }

--- a/proto/sentry_protos/billing/v1/services/engagement/v1/endpoint_get_active_grants.proto
+++ b/proto/sentry_protos/billing/v1/services/engagement/v1/endpoint_get_active_grants.proto
@@ -5,6 +5,7 @@ package sentry_protos.billing.v1.services.engagement.v1;
 import "sentry_protos/billing/v1/date.proto";
 
 message UnitGrant {
+  option deprecated = true;
   string line_item_uid = 1;
   oneof amount {
     bool is_unlimited = 2;
@@ -14,18 +15,21 @@ message UnitGrant {
 }
 
 enum MonetaryType {
+  option deprecated = true;
   MONETARY_TYPE_UNSPECIFIED = 0;
   MONETARY_TYPE_CENTS = 1;
   MONETARY_TYPE_PERCENT = 2;
 }
 
 message MonetaryGrant {
+  option deprecated = true;
   // PERCENT amounts are percentage points: 10 = 10%
   uint64 amount = 1;
   MonetaryType type = 2;
 }
 
 message ActiveGrant {
+  option deprecated = true;
   oneof kind {
     UnitGrant unit = 1;
     MonetaryGrant monetary = 2;
@@ -39,11 +43,13 @@ message ActiveGrant {
 }
 
 message GetActiveGrantsRequest {
+  option deprecated = true;
   uint64 organization_id = 1;
   sentry_protos.billing.v1.Date start_date = 3;
   sentry_protos.billing.v1.Date end_date = 4;
 }
 
 message GetActiveGrantsResponse {
+  option deprecated = true;
   repeated ActiveGrant grants = 1;
 }

--- a/proto/sentry_protos/billing/v1/services/engagement/v1/endpoint_get_effective_grants.proto
+++ b/proto/sentry_protos/billing/v1/services/engagement/v1/endpoint_get_effective_grants.proto
@@ -8,6 +8,7 @@ import "sentry_protos/billing/v1/services/engagement/v1/grant.proto";
 // A grant with counter-grant chains collapsed into a single effective amount.
 // Returned in drain priority order (end_date ASC, effective_amount ASC, grant_id ASC).
 message EffectiveGrant {
+  option deprecated = true;
   uint64 grant_id = 1;
   GrantType type = 2;
   repeated string line_item_uids = 3;
@@ -22,6 +23,7 @@ message EffectiveGrant {
 }
 
 message GetEffectiveGrantsRequest {
+  option deprecated = true;
   uint64 organization_id = 1;
   // When set, returns only grants whose line_item_uids contain this value.
   optional string line_item_uid = 2;
@@ -36,6 +38,7 @@ message GetEffectiveGrantsRequest {
 }
 
 message GetEffectiveGrantsResponse {
+  option deprecated = true;
   // Grants with counter-chains collapsed, sorted by drain priority.
   repeated EffectiveGrant effective_grants = 1;
 }

--- a/proto/sentry_protos/billing/v1/services/engagement/v1/endpoint_get_monetary_grants.proto
+++ b/proto/sentry_protos/billing/v1/services/engagement/v1/endpoint_get_monetary_grants.proto
@@ -1,0 +1,30 @@
+syntax = "proto3";
+
+package sentry_protos.billing.v1.services.engagement.v1;
+
+enum EffectiveMonetaryType {
+  EFFECTIVE_MONETARY_TYPE_UNSPECIFIED = 0;
+  EFFECTIVE_MONETARY_TYPE_CENTS = 1;
+  EFFECTIVE_MONETARY_TYPE_PERCENT = 2;
+}
+
+enum EffectiveMonetarySource {
+  EFFECTIVE_MONETARY_SOURCE_UNSPECIFIED = 0;
+  EFFECTIVE_MONETARY_SOURCE_BALANCE = 1;
+  EFFECTIVE_MONETARY_SOURCE_RECURRING_CREDIT = 2;
+}
+
+message EffectiveMonetaryGrant {
+  // PERCENT amounts are percentage points: 10 = 10%
+  uint64 amount = 1;
+  EffectiveMonetaryType type = 2;
+  EffectiveMonetarySource source = 3;
+}
+
+message GetMonetaryGrantsRequest {
+  uint64 contract_id = 1;
+}
+
+message GetMonetaryGrantsResponse {
+  repeated EffectiveMonetaryGrant monetary_grants = 1;
+}

--- a/proto/sentry_protos/billing/v1/services/engagement/v1/endpoint_get_unit_grants.proto
+++ b/proto/sentry_protos/billing/v1/services/engagement/v1/endpoint_get_unit_grants.proto
@@ -1,0 +1,29 @@
+syntax = "proto3";
+
+package sentry_protos.billing.v1.services.engagement.v1;
+
+import "sentry_protos/billing/v1/date.proto";
+
+message EffectiveUnitGrant {
+  string line_item_uid = 1;
+  oneof amount {
+    bool is_unlimited = 2;
+    // this should be expressed line item's billable metric prior to unit conversion (ie milliseconds, bytes, etc.)
+    uint64 units = 3;
+  }
+  // Grants only apply to days between [start_date, end_date] (inclusive)
+  // For units, this means Grants apply to usage that was accrued during the active period.
+  // For monetary, Grants are applied to invoices created during the active period.
+  sentry_protos.billing.v1.Date start_date = 4;
+  sentry_protos.billing.v1.Date end_date = 5;
+}
+
+message GetUnitGrantsRequest {
+  uint64 organization_id = 1;
+  sentry_protos.billing.v1.Date start_date = 3;
+  sentry_protos.billing.v1.Date end_date = 4;
+}
+
+message GetUnitGrantsResponse {
+  repeated EffectiveUnitGrant grants = 1;
+}

--- a/proto/sentry_protos/billing/v1/services/engagement/v1/endpoint_get_unit_grants.proto
+++ b/proto/sentry_protos/billing/v1/services/engagement/v1/endpoint_get_unit_grants.proto
@@ -19,9 +19,7 @@ message EffectiveUnitGrant {
 }
 
 message GetUnitGrantsRequest {
-  uint64 organization_id = 1;
-  sentry_protos.billing.v1.Date start_date = 3;
-  sentry_protos.billing.v1.Date end_date = 4;
+  uint64 contract_id = 1;
 }
 
 message GetUnitGrantsResponse {

--- a/proto/sentry_protos/billing/v1/services/engagement/v1/grant.proto
+++ b/proto/sentry_protos/billing/v1/services/engagement/v1/grant.proto
@@ -7,6 +7,7 @@ import "sentry_protos/billing/v1/services/engagement/v1/grant_source.proto";
 
 // Denomination of a Grant.
 enum GrantType {
+  option deprecated = true;
   GRANT_TYPE_UNSPECIFIED = 0;
   // A quantity of units for specific line items.
   GRANT_TYPE_UNITS = 1;
@@ -16,6 +17,7 @@ enum GrantType {
 
 // Lifecycle state of a Grant.
 enum GrantStatus {
+  option deprecated = true;
   GRANT_STATUS_UNSPECIFIED = 0;
   // Consumable now; within [start_date, end_date].
   GRANT_STATUS_ACTIVE = 1;
@@ -35,6 +37,7 @@ enum GrantStatus {
 // UNITS grants have exactly one entry in line_item_uids. CENTS grants may
 // have several.
 message Grant {
+  option deprecated = true;
   uint64 id = 1;
   uint64 organization_id = 2;
   GrantType type = 3;

--- a/proto/sentry_protos/billing/v1/services/engagement/v1/grant_source.proto
+++ b/proto/sentry_protos/billing/v1/services/engagement/v1/grant_source.proto
@@ -4,6 +4,7 @@ package sentry_protos.billing.v1.services.engagement.v1;
 
 // How a Grant was created.
 enum GrantSource {
+  option deprecated = true;
   GRANT_SOURCE_UNSPECIFIED = 0;
 
   // Derived from a Trial row.

--- a/rust/src/sentry_protos.billing.v1.services.engagement.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.engagement.v1.rs
@@ -354,6 +354,123 @@ pub struct GetEffectiveGrantsResponse {
     #[prost(message, repeated, tag = "1")]
     pub effective_grants: ::prost::alloc::vec::Vec<EffectiveGrant>,
 }
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct EffectiveMonetaryGrant {
+    /// PERCENT amounts are percentage points: 10 = 10%
+    #[prost(uint64, tag = "1")]
+    pub amount: u64,
+    #[prost(enumeration = "EffectiveMonetaryType", tag = "2")]
+    pub r#type: i32,
+    #[prost(enumeration = "EffectiveMonetarySource", tag = "3")]
+    pub source: i32,
+}
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct GetMonetaryGrantsRequest {
+    #[prost(uint64, tag = "1")]
+    pub contract_id: u64,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetMonetaryGrantsResponse {
+    #[prost(message, repeated, tag = "1")]
+    pub monetary_grants: ::prost::alloc::vec::Vec<EffectiveMonetaryGrant>,
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum EffectiveMonetaryType {
+    Unspecified = 0,
+    Cents = 1,
+    Percent = 2,
+}
+impl EffectiveMonetaryType {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Self::Unspecified => "EFFECTIVE_MONETARY_TYPE_UNSPECIFIED",
+            Self::Cents => "EFFECTIVE_MONETARY_TYPE_CENTS",
+            Self::Percent => "EFFECTIVE_MONETARY_TYPE_PERCENT",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "EFFECTIVE_MONETARY_TYPE_UNSPECIFIED" => Some(Self::Unspecified),
+            "EFFECTIVE_MONETARY_TYPE_CENTS" => Some(Self::Cents),
+            "EFFECTIVE_MONETARY_TYPE_PERCENT" => Some(Self::Percent),
+            _ => None,
+        }
+    }
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum EffectiveMonetarySource {
+    Unspecified = 0,
+    Balance = 1,
+    RecurringCredit = 2,
+}
+impl EffectiveMonetarySource {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Self::Unspecified => "EFFECTIVE_MONETARY_SOURCE_UNSPECIFIED",
+            Self::Balance => "EFFECTIVE_MONETARY_SOURCE_BALANCE",
+            Self::RecurringCredit => "EFFECTIVE_MONETARY_SOURCE_RECURRING_CREDIT",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "EFFECTIVE_MONETARY_SOURCE_UNSPECIFIED" => Some(Self::Unspecified),
+            "EFFECTIVE_MONETARY_SOURCE_BALANCE" => Some(Self::Balance),
+            "EFFECTIVE_MONETARY_SOURCE_RECURRING_CREDIT" => Some(Self::RecurringCredit),
+            _ => None,
+        }
+    }
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct EffectiveUnitGrant {
+    #[prost(string, tag = "1")]
+    pub line_item_uid: ::prost::alloc::string::String,
+    /// Grants only apply to days between \[start_date, end_date\] (inclusive)
+    /// For units, this means Grants apply to usage that was accrued during the active period.
+    /// For monetary, Grants are applied to invoices created during the active period.
+    #[prost(message, optional, tag = "4")]
+    pub start_date: ::core::option::Option<super::super::super::Date>,
+    #[prost(message, optional, tag = "5")]
+    pub end_date: ::core::option::Option<super::super::super::Date>,
+    #[prost(oneof = "effective_unit_grant::Amount", tags = "2, 3")]
+    pub amount: ::core::option::Option<effective_unit_grant::Amount>,
+}
+/// Nested message and enum types in `EffectiveUnitGrant`.
+pub mod effective_unit_grant {
+    #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Oneof)]
+    pub enum Amount {
+        #[prost(bool, tag = "2")]
+        IsUnlimited(bool),
+        /// this should be expressed line item's billable metric prior to unit conversion (ie milliseconds, bytes, etc.)
+        #[prost(uint64, tag = "3")]
+        Units(u64),
+    }
+}
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct GetUnitGrantsRequest {
+    #[prost(uint64, tag = "1")]
+    pub organization_id: u64,
+    #[prost(message, optional, tag = "3")]
+    pub start_date: ::core::option::Option<super::super::super::Date>,
+    #[prost(message, optional, tag = "4")]
+    pub end_date: ::core::option::Option<super::super::super::Date>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetUnitGrantsResponse {
+    #[prost(message, repeated, tag = "1")]
+    pub grants: ::prost::alloc::vec::Vec<EffectiveUnitGrant>,
+}
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct StartTrialRequest {
     #[prost(uint64, tag = "1")]

--- a/rust/src/sentry_protos.billing.v1.services.engagement.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.engagement.v1.rs
@@ -460,11 +460,7 @@ pub mod effective_unit_grant {
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct GetUnitGrantsRequest {
     #[prost(uint64, tag = "1")]
-    pub organization_id: u64,
-    #[prost(message, optional, tag = "3")]
-    pub start_date: ::core::option::Option<super::super::super::Date>,
-    #[prost(message, optional, tag = "4")]
-    pub end_date: ::core::option::Option<super::super::super::Date>,
+    pub contract_id: u64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetUnitGrantsResponse {


### PR DESCRIPTION
Unit and monetary grants have vastly different return shapes and use cases. It makes more sense to separate them from a single ActiveGrant message to avoid porting unnecessary fields to both grant types.

Also deprecates a bunch of messages that will not be used.