### PR TITLE
feat(eap): add typed array types for int/double/bool/string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/snuba/v1/trace_item_attribute.proto
+++ b/proto/sentry_protos/snuba/v1/trace_item_attribute.proto
@@ -11,7 +11,12 @@ message AttributeKey {
     TYPE_FLOAT = 3 [deprecated = true];
     TYPE_INT = 4; //note: all numbers are stored as float64, so massive integers can be rounded. USE STRING FOR IDS.
     TYPE_DOUBLE = 5;
-    TYPE_ARRAY = 6;
+    // deprecated, use TYPE_ARRAY_INT/DOUBLE/BOOL/STRING instead
+    TYPE_ARRAY = 6 [deprecated = true];
+    TYPE_ARRAY_INT = 7;
+    TYPE_ARRAY_DOUBLE = 8;
+    TYPE_ARRAY_BOOL = 9;
+    TYPE_ARRAY_STRING = 10;
   }
 
   Type type = 1;

--- a/rust/src/sentry_protos.snuba.v1.rs
+++ b/rust/src/sentry_protos.snuba.v1.rs
@@ -35,7 +35,13 @@ pub mod attribute_key {
         /// note: all numbers are stored as float64, so massive integers can be rounded. USE STRING FOR IDS.
         Int = 4,
         Double = 5,
+        /// deprecated, use TYPE_ARRAY_INT/DOUBLE/BOOL/STRING instead
+        #[deprecated]
         Array = 6,
+        ArrayInt = 7,
+        ArrayDouble = 8,
+        ArrayBool = 9,
+        ArrayString = 10,
     }
     impl Type {
         /// String value of the enum field names used in the ProtoBuf definition.
@@ -51,7 +57,12 @@ pub mod attribute_key {
                 Self::Float => "TYPE_FLOAT",
                 Self::Int => "TYPE_INT",
                 Self::Double => "TYPE_DOUBLE",
+                #[allow(deprecated)]
                 Self::Array => "TYPE_ARRAY",
+                Self::ArrayInt => "TYPE_ARRAY_INT",
+                Self::ArrayDouble => "TYPE_ARRAY_DOUBLE",
+                Self::ArrayBool => "TYPE_ARRAY_BOOL",
+                Self::ArrayString => "TYPE_ARRAY_STRING",
             }
         }
         /// Creates an enum from field names used in the ProtoBuf definition.
@@ -63,7 +74,11 @@ pub mod attribute_key {
                 "TYPE_FLOAT" => Some(#[allow(deprecated)] Self::Float),
                 "TYPE_INT" => Some(Self::Int),
                 "TYPE_DOUBLE" => Some(Self::Double),
-                "TYPE_ARRAY" => Some(Self::Array),
+                "TYPE_ARRAY" => Some(#[allow(deprecated)] Self::Array),
+                "TYPE_ARRAY_INT" => Some(Self::ArrayInt),
+                "TYPE_ARRAY_DOUBLE" => Some(Self::ArrayDouble),
+                "TYPE_ARRAY_BOOL" => Some(Self::ArrayBool),
+                "TYPE_ARRAY_STRING" => Some(Self::ArrayString),
                 _ => None,
             }
         }


### PR DESCRIPTION
## Summary

- Adds `TYPE_ARRAY_INT`, `TYPE_ARRAY_DOUBLE`, `TYPE_ARRAY_BOOL`, `TYPE_ARRAY_STRING` to `AttributeKey.Type` enum in `trace_item_attribute.proto`
- Deprecates the generic `TYPE_ARRAY = 6` in favor of these typed variants
- Allows callers to differentiate array element types rather than using a single catch-all array type

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y6Ejta9LDKkW86WBS6wF6h)_