### PR TITLE
chore(billing-platform): Add new contract id in RolloverContractResponse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_rollover_contract.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_rollover_contract.proto
@@ -30,4 +30,5 @@ message RolloverContractResponse {
   uint64 invoice_id = 1;
   bool needs_charge = 2;
   uint64 amount_billed = 3;
+  uint64 new_contract_id = 4;
 }

--- a/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
@@ -743,4 +743,6 @@ pub struct RolloverContractResponse {
     pub needs_charge: bool,
     #[prost(uint64, tag = "3")]
     pub amount_billed: u64,
+    #[prost(uint64, tag = "4")]
+    pub new_contract_id: u64,
 }


### PR DESCRIPTION
addresses https://github.com/getsentry/getsentry/pull/20853#discussion_r3500856350

saves us from having to fetch the next contract when rolling over balances