### PR TITLE
ref: Add legacy data category field to line items

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/common/v1/line_item_details.proto
+++ b/proto/sentry_protos/billing/v1/common/v1/line_item_details.proto
@@ -21,4 +21,12 @@ message LineItemDetails {
 
   // Defines how usage data is transformed into this line item.
   BillableMetric billable_metric = 6;
+
+  // DEPRECATED: do not use. The getsentry DataCategory value this line item
+  // bills (the unified getsentry/sentry DataCategory int, NOT the proto
+  // sentry_protos.billing.v1.DataCategory enum). Exists only to support legacy
+  // code that hardcodes category values during the billing-platform migration.
+  // New line items must be addable, and new consumers written, without anyone
+  // hardcoding or reading a category off the line item.
+  int32 line_item_category = 7 [deprecated = true];
 }

--- a/rust/src/sentry_protos.billing.v1.common.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.common.v1.rs
@@ -236,6 +236,15 @@ pub struct LineItemDetails {
     /// Defines how usage data is transformed into this line item.
     #[prost(message, optional, tag = "6")]
     pub billable_metric: ::core::option::Option<BillableMetric>,
+    /// DEPRECATED: do not use. The getsentry DataCategory value this line item
+    /// bills (the unified getsentry/sentry DataCategory int, NOT the proto
+    /// sentry_protos.billing.v1.DataCategory enum). Exists only to support legacy
+    /// code that hardcodes category values during the billing-platform migration.
+    /// New line items must be addable, and new consumers written, without anyone
+    /// hardcoding or reading a category off the line item.
+    #[deprecated]
+    #[prost(int32, tag = "7")]
+    pub line_item_category: i32,
 }
 /// Stripe-specific payment information for an organization.
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]


### PR DESCRIPTION
See https://app.notion.com/p/sentry/How-to-handle-data-categories-on-frontend-38f8b10e4b5d8043921df455fa3de898?source=copy_link for details on why we decided to use this