### PR TITLE
chore(billing-platform): Include previous contract id in contract proto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.37.1"
+version = "0.37.2"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/services/contract/v1/contract_metadata.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/contract_metadata.proto
@@ -44,6 +44,8 @@ message ContractMetadata {
   sentry_protos.billing.v1.FeatureOptions billing_features = 7;
   string package_uid = 9;
 
+  optional uint64 previous_id = 10;
+
   uint64 package_id = 8 [deprecated = true];
   // Includes information like plan ID, tier, etc.
   MetadataOptions package_metadata = 4 [deprecated = true];

--- a/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
@@ -472,6 +472,8 @@ pub struct ContractMetadata {
     pub billing_features: ::core::option::Option<super::super::super::FeatureOptions>,
     #[prost(string, tag = "9")]
     pub package_uid: ::prost::alloc::string::String,
+    #[prost(uint64, optional, tag = "10")]
+    pub previous_id: ::core::option::Option<u64>,
     #[deprecated]
     #[prost(uint64, tag = "8")]
     pub package_id: u64,


### PR DESCRIPTION
Need to expose this for some EngagementService methods