### PR TITLE
feat(billing): Add GetPackageForTier package-service endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.37.2"
+version = "0.37.3"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/services/package/v1/endpoint_get_package_for_tier.proto
+++ b/proto/sentry_protos/billing/v1/services/package/v1/endpoint_get_package_for_tier.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+
+package sentry_protos.billing.v1.services.package.v1;
+
+import "sentry_protos/billing/v1/services/package/v1/package.proto";
+
+enum PackageTier {
+  PACKAGE_TIER_UNSPECIFIED = 0;
+  PACKAGE_TIER_FREE = 1;
+  PACKAGE_TIER_TEAM = 2;
+  PACKAGE_TIER_BUSINESS = 3;
+}
+
+message GetPackageForTierRequest {
+  string package_uid = 1;
+  PackageTier tier = 2;
+}
+
+message GetPackageForTierResponse {
+  PackageConfig package_config = 1;
+}

--- a/rust/src/sentry_protos.billing.v1.services.package.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.package.v1.rs
@@ -166,3 +166,47 @@ pub struct GetPackageResponse {
     #[prost(message, optional, tag = "1")]
     pub package_config: ::core::option::Option<PackageConfig>,
 }
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct GetPackageForTierRequest {
+    #[prost(string, tag = "1")]
+    pub package_uid: ::prost::alloc::string::String,
+    #[prost(enumeration = "PackageTier", tag = "2")]
+    pub tier: i32,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetPackageForTierResponse {
+    #[prost(message, optional, tag = "1")]
+    pub package_config: ::core::option::Option<PackageConfig>,
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum PackageTier {
+    Unspecified = 0,
+    Free = 1,
+    Team = 2,
+    Business = 3,
+}
+impl PackageTier {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Self::Unspecified => "PACKAGE_TIER_UNSPECIFIED",
+            Self::Free => "PACKAGE_TIER_FREE",
+            Self::Team => "PACKAGE_TIER_TEAM",
+            Self::Business => "PACKAGE_TIER_BUSINESS",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "PACKAGE_TIER_UNSPECIFIED" => Some(Self::Unspecified),
+            "PACKAGE_TIER_FREE" => Some(Self::Free),
+            "PACKAGE_TIER_TEAM" => Some(Self::Team),
+            "PACKAGE_TIER_BUSINESS" => Some(Self::Business),
+            _ => None,
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `GetPackageForTier` package-service endpoint plus a `PackageTier` enum, for resolving the package at a given tier within a package family.

- `enum PackageTier { UNSPECIFIED, FREE, TEAM, BUSINESS }`
- `GetPackageForTierRequest { string package_uid; PackageTier tier }`
- `GetPackageForTierResponse { PackageConfig package_config }`

Given a package uid (which identifies the family) and a target tier, returns the corresponding package — e.g. the free-tier package an org moves to when its paid subscription is cancelled.

## Consumer

Implemented in getsentry as `PackageService.get_package_for_tier` (interface only for now) — see getsentry#20915 (REVENG-296).

## Note

Supersedes the earlier `GetDowngradePackage` approach on this branch: a general tier resolver is more reusable than a free-only "downgrade" lookup.

Refs REVENG-296