### PR TITLE
feat(eap): Add filter support to ExportTraceItemsRequest endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.37.2"
+version = "0.37.3"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/snuba/v1/endpoint_trace_items.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_trace_items.proto
@@ -3,11 +3,14 @@ package sentry_protos.snuba.v1;
 
 import "sentry_protos/snuba/v1/request_common.proto";
 import "sentry_protos/snuba/v1/trace_item.proto";
+import "sentry_protos/snuba/v1/trace_item_filter.proto";
 
 message ExportTraceItemsRequest {
   RequestMeta meta = 1;
   PageToken page_token = 2;
   uint32 limit = 3;
+  // filter out trace items you dont want
+  TraceItemFilter filter = 4;
 }
 
 message ExportTraceItemsResponse {

--- a/py/tests/test_snuba_v1.py
+++ b/py/tests/test_snuba_v1.py
@@ -85,6 +85,16 @@ from sentry_protos.snuba.v1.endpoint_trace_item_details_pb2 import (
     TraceItemDetailsResponse,
 )
 
+from sentry_protos.snuba.v1.endpoint_trace_items_pb2 import (
+    ExportTraceItemsRequest,
+    ExportTraceItemsResponse,
+)
+
+from sentry_protos.snuba.v1.trace_item_pb2 import (
+    TraceItem,
+    AnyValue,
+)
+
 COMMON_META = RequestMeta(
     project_ids=[1, 2, 3],
     organization_id=1,
@@ -423,6 +433,82 @@ def test_trace_item_details() -> None:
             )
         ]
     )
+
+def test_export_trace_items() -> None:
+    # Filter clause is optional
+    ExportTraceItemsRequest(
+        meta=COMMON_META,
+        page_token=PageToken(
+            filter_offset=TraceItemFilter(
+                comparison_filter=ComparisonFilter(
+                    key=AttributeKey(
+                        type=AttributeKey.TYPE_DOUBLE, name="sentry.duration"
+                    ),
+                    op=ComparisonFilter.OP_GREATER_THAN_OR_EQUALS,
+                    value=AttributeValue(val_double=6.9),
+                )
+            )
+        ),
+        limit=100,
+    )
+
+    # Filter clause is parsed properly
+    ExportTraceItemsRequest(
+        meta=COMMON_META,
+        page_token=PageToken(
+            filter_offset=TraceItemFilter(
+                comparison_filter=ComparisonFilter(
+                    key=AttributeKey(
+                        type=AttributeKey.TYPE_DOUBLE, name="sentry.duration"
+                    ),
+                    op=ComparisonFilter.OP_GREATER_THAN_OR_EQUALS,
+                    value=AttributeValue(val_double=6.9),
+                )
+            )
+        ),
+        limit=100,
+        filter=TraceItemFilter(
+            comparison_filter=ComparisonFilter(
+                key=AttributeKey(
+                    type=AttributeKey.TYPE_STRING,
+                    name="sentry.span_name",
+                ),
+                op=ComparisonFilter.OP_EQUALS,
+                value=AttributeValue(val_str="database_query"),
+            ),
+        ),
+    )
+
+    ExportTraceItemsResponse(
+        trace_items=[
+            TraceItem(
+                organization_id=1,
+                project_id=1,
+                trace_id="1234567890abcdef",
+                item_id=b"1234567812345678",
+                item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+                timestamp=COMMON_META.start_timestamp,
+                attributes={
+                    "sentry.span_name": AnyValue(string_value="database_query"),
+                    "sentry.duration": AnyValue(double_value=7.2),
+                },
+                client_sample_rate=1.0,
+                server_sample_rate=0.1,
+            ),
+        ],
+        page_token=PageToken(
+            filter_offset=TraceItemFilter(
+                comparison_filter=ComparisonFilter(
+                    key=AttributeKey(
+                        type=AttributeKey.TYPE_DOUBLE, name="sentry.duration"
+                    ),
+                    op=ComparisonFilter.OP_GREATER_THAN_OR_EQUALS,
+                    value=AttributeValue(val_double=6.9),
+                )
+            )
+        ),
+    )
+
 
 def test_example_find_traces() -> None:
     # Find traces that contain a span event with a `span_name` of "database_query"

--- a/rust/src/sentry_protos.snuba.v1.rs
+++ b/rust/src/sentry_protos.snuba.v1.rs
@@ -2603,6 +2603,9 @@ pub struct ExportTraceItemsRequest {
     pub page_token: ::core::option::Option<PageToken>,
     #[prost(uint32, tag = "3")]
     pub limit: u32,
+    /// filter out trace items you dont want
+    #[prost(message, optional, tag = "4")]
+    pub filter: ::core::option::Option<TraceItemFilter>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExportTraceItemsResponse {


### PR DESCRIPTION
Add a `filter` keyword for the `ExportTraceItemsRequest`; mirroring `TraceItemTableRequest`'s filter.

Consumed in getsentry/snuba#8152