### PR TITLE
feat(billing): protos for master-dataclass promotion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/services/charge/v1/charge.proto
+++ b/proto/sentry_protos/billing/v1/services/charge/v1/charge.proto
@@ -31,9 +31,7 @@ message PlatformCharge {
   // sum ``refunds[*].amount_cents`` if they need the aggregate, and
   // ``len(refunds) > 0`` (or sum == amount) signals "refunded."
   repeated PlatformRefund refunds = 10;
-  // Unix epoch seconds when the charge row was created locally. Mirrors
-  // PlatformRefund.date_added_st so consumers that render mixed charge +
-  // refund timelines can sort them off a single time axis.
+  // Unix epoch seconds when the charge row was created locally.
   int64 date_added_st = 11;
 }
 

--- a/proto/sentry_protos/billing/v1/services/charge/v1/charge.proto
+++ b/proto/sentry_protos/billing/v1/services/charge/v1/charge.proto
@@ -31,6 +31,10 @@ message PlatformCharge {
   // sum ``refunds[*].amount_cents`` if they need the aggregate, and
   // ``len(refunds) > 0`` (or sum == amount) signals "refunded."
   repeated PlatformRefund refunds = 10;
+  // Unix epoch seconds when the charge row was created locally. Mirrors
+  // PlatformRefund.date_added_st so consumers that render mixed charge +
+  // refund timelines can sort them off a single time axis.
+  int64 date_added_st = 11;
 }
 
 // Canonical projection of a stored platform refund. One row per recorded

--- a/proto/sentry_protos/billing/v1/services/charge/v1/endpoint_list_charges_for_invoice_ids.proto
+++ b/proto/sentry_protos/billing/v1/services/charge/v1/endpoint_list_charges_for_invoice_ids.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package sentry_protos.billing.v1.services.charge.v1;
+
+import "sentry_protos/billing/v1/services/charge/v1/charge.proto";
+
+// Lists every recorded PlatformCharge for a batch of invoice ids, ordered by
+// (invoice_id, date_added_st) ascending, with each charge's refunds
+// pre-attached. Used by presentation surfaces that render full charge +
+// refund history for a customer's invoices.
+message ListChargesForInvoiceIdsRequest {
+  repeated uint64 invoice_ids = 1;
+}
+
+message ListChargesForInvoiceIdsResponse {
+  repeated PlatformCharge charges = 1;
+}

--- a/proto/sentry_protos/billing/v1/services/charge/v1/endpoint_list_charges_for_invoice_ids.proto
+++ b/proto/sentry_protos/billing/v1/services/charge/v1/endpoint_list_charges_for_invoice_ids.proto
@@ -4,10 +4,7 @@ package sentry_protos.billing.v1.services.charge.v1;
 
 import "sentry_protos/billing/v1/services/charge/v1/charge.proto";
 
-// Lists every recorded PlatformCharge for a batch of invoice ids, ordered by
-// (invoice_id, date_added_st) ascending, with each charge's refunds
-// pre-attached. Used by presentation surfaces that render full charge +
-// refund history for a customer's invoices.
+// Lists PlatformCharges for a batch of invoice ids, refunds pre-attached.
 message ListChargesForInvoiceIdsRequest {
   repeated uint64 invoice_ids = 1;
 }

--- a/proto/sentry_protos/billing/v1/services/charge/v1/endpoint_list_charges_for_organization.proto
+++ b/proto/sentry_protos/billing/v1/services/charge/v1/endpoint_list_charges_for_organization.proto
@@ -4,8 +4,7 @@ package sentry_protos.billing.v1.services.charge.v1;
 
 import "sentry_protos/billing/v1/services/charge/v1/charge.proto";
 
-// Lists every recorded PlatformCharge owned by an organization, ordered by
-// date_added_st ascending, with each charge's refunds pre-attached.
+// Lists PlatformCharges for an organization, refunds pre-attached.
 message ListChargesForOrganizationRequest {
   uint64 organization_id = 1;
 }

--- a/proto/sentry_protos/billing/v1/services/charge/v1/endpoint_list_charges_for_organization.proto
+++ b/proto/sentry_protos/billing/v1/services/charge/v1/endpoint_list_charges_for_organization.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package sentry_protos.billing.v1.services.charge.v1;
+
+import "sentry_protos/billing/v1/services/charge/v1/charge.proto";
+
+// Lists every recorded PlatformCharge owned by an organization, ordered by
+// date_added_st ascending, with each charge's refunds pre-attached.
+message ListChargesForOrganizationRequest {
+  uint64 organization_id = 1;
+}
+
+message ListChargesForOrganizationResponse {
+  repeated PlatformCharge charges = 1;
+}

--- a/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_get_invoice_guids_for_ids.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_get_invoice_guids_for_ids.proto
@@ -2,16 +2,12 @@ syntax = "proto3";
 
 package sentry_protos.billing.v1.services.contract.v1;
 
-// Batch-resolves PlatformInvoice ids to their guids. Caller is responsible
-// for passing only ids it has the right to see; this endpoint does not
-// filter by organization. Missing ids are silently omitted from the
-// response.
+// Batch-resolves PlatformInvoice ids to their guids. Missing ids are
+// silently omitted from the response.
 message GetInvoiceGuidsForIdsRequest {
   repeated uint64 invoice_ids = 1;
 }
 
 message GetInvoiceGuidsForIdsResponse {
-  // Mapping from invoice id to guid for every invoice that was found.
-  // Empty when the request supplied no ids or none of them matched.
   map<uint64, string> invoice_guids = 1;
 }

--- a/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_get_invoice_guids_for_ids.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_get_invoice_guids_for_ids.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package sentry_protos.billing.v1.services.contract.v1;
+
+// Batch-resolves PlatformInvoice ids to their guids. Caller is responsible
+// for passing only ids it has the right to see; this endpoint does not
+// filter by organization. Missing ids are silently omitted from the
+// response.
+message GetInvoiceGuidsForIdsRequest {
+  repeated uint64 invoice_ids = 1;
+}
+
+message GetInvoiceGuidsForIdsResponse {
+  // Mapping from invoice id to guid for every invoice that was found.
+  // Empty when the request supplied no ids or none of them matched.
+  map<uint64, string> invoice_guids = 1;
+}

--- a/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_start_manual_payment.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_start_manual_payment.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+
+package sentry_protos.billing.v1.services.contract.v1;
+
+// Atomically stamps manual_payment_started_at on an unpaid PlatformInvoice,
+// locking it from automated billing for 24h while the user completes a manual
+// Pay Now flow via Stripe.js.
+message StartManualPaymentRequest {
+  uint64 invoice_id = 1;
+}
+
+message StartManualPaymentResponse {
+  // False when no row was updated. That covers three cases: invoice id
+  // unknown, the row is already paid, or the row was paid in the window
+  // between the caller's last read and this call. The third case is the
+  // race that the atomic ``WHERE paid=false`` filter closes -- callers
+  // can treat ``updated=false`` as "the invoice is no longer in a payable
+  // state, discard any side effects you took in the meantime."
+  bool updated = 1;
+}

--- a/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_start_manual_payment.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_start_manual_payment.proto
@@ -2,19 +2,12 @@ syntax = "proto3";
 
 package sentry_protos.billing.v1.services.contract.v1;
 
-// Atomically stamps manual_payment_started_at on an unpaid PlatformInvoice,
-// locking it from automated billing for 24h while the user completes a manual
-// Pay Now flow via Stripe.js.
+// Atomically stamps manual_payment_started_at on an unpaid PlatformInvoice.
 message StartManualPaymentRequest {
   uint64 invoice_id = 1;
 }
 
 message StartManualPaymentResponse {
-  // False when no row was updated. That covers three cases: invoice id
-  // unknown, the row is already paid, or the row was paid in the window
-  // between the caller's last read and this call. The third case is the
-  // race that the atomic ``WHERE paid=false`` filter closes -- callers
-  // can treat ``updated=false`` as "the invoice is no longer in a payable
-  // state, discard any side effects you took in the meantime."
+  // False when no row matched paid=false (invoice paid, missing, or raced).
   bool updated = 1;
 }

--- a/rust/src/sentry_protos.billing.v1.services.charge.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.charge.v1.rs
@@ -41,6 +41,9 @@ pub struct PlatformCharge {
     /// `len(refunds) > 0` (or sum == amount) signals "refunded."
     #[prost(message, repeated, tag = "10")]
     pub refunds: ::prost::alloc::vec::Vec<PlatformRefund>,
+    /// Unix epoch seconds when the charge row was created locally.
+    #[prost(int64, tag = "11")]
+    pub date_added_st: i64,
 }
 /// Canonical projection of a stored platform refund. One row per recorded
 /// refund against a `PlatformCharge`.
@@ -167,6 +170,28 @@ pub struct ListChargesForInvoiceRequest {
 pub struct ListChargesForInvoiceResponse {
     #[prost(message, repeated, tag = "1")]
     pub charges: ::prost::alloc::vec::Vec<Charge>,
+}
+/// Lists PlatformCharges for a batch of invoice ids, refunds pre-attached.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ListChargesForInvoiceIdsRequest {
+    #[prost(uint64, repeated, tag = "1")]
+    pub invoice_ids: ::prost::alloc::vec::Vec<u64>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListChargesForInvoiceIdsResponse {
+    #[prost(message, repeated, tag = "1")]
+    pub charges: ::prost::alloc::vec::Vec<PlatformCharge>,
+}
+/// Lists PlatformCharges for an organization, refunds pre-attached.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ListChargesForOrganizationRequest {
+    #[prost(uint64, tag = "1")]
+    pub organization_id: u64,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListChargesForOrganizationResponse {
+    #[prost(message, repeated, tag = "1")]
+    pub charges: ::prost::alloc::vec::Vec<PlatformCharge>,
 }
 /// Lists every recorded refund associated with the charges for a single
 /// platform invoice. Callers in the presentation layer use this to render

--- a/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
@@ -472,6 +472,8 @@ pub struct ContractMetadata {
     pub billing_features: ::core::option::Option<super::super::super::FeatureOptions>,
     #[prost(string, tag = "9")]
     pub package_uid: ::prost::alloc::string::String,
+    #[prost(uint64, optional, tag = "10")]
+    pub previous_id: ::core::option::Option<u64>,
     #[deprecated]
     #[prost(uint64, tag = "8")]
     pub package_id: u64,
@@ -583,6 +585,18 @@ pub struct GetInvoiceRequest {
 pub struct GetInvoiceResponse {
     #[prost(message, optional, tag = "1")]
     pub invoice: ::core::option::Option<Invoice>,
+}
+/// Batch-resolves PlatformInvoice ids to their guids. Missing ids are
+/// silently omitted from the response.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct GetInvoiceGuidsForIdsRequest {
+    #[prost(uint64, repeated, tag = "1")]
+    pub invoice_ids: ::prost::alloc::vec::Vec<u64>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetInvoiceGuidsForIdsResponse {
+    #[prost(map = "uint64, string", tag = "1")]
+    pub invoice_guids: ::std::collections::HashMap<u64, ::prost::alloc::string::String>,
 }
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct GetUnchargedInvoicesRequest {
@@ -745,4 +759,16 @@ pub struct RolloverContractResponse {
     pub amount_billed: u64,
     #[prost(uint64, tag = "4")]
     pub new_contract_id: u64,
+}
+/// Atomically stamps manual_payment_started_at on an unpaid PlatformInvoice.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct StartManualPaymentRequest {
+    #[prost(uint64, tag = "1")]
+    pub invoice_id: u64,
+}
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct StartManualPaymentResponse {
+    /// False when no row matched paid=false (invoice paid, missing, or raced).
+    #[prost(bool, tag = "1")]
+    pub updated: bool,
 }


### PR DESCRIPTION
Promotes several dataclass prototypes already in use on getsentry master to real protos. Companion to a getsentry-side promotion PR (getsentry/getsentry#20887) that will bump the `sentry-protos` pin once this lands.

## Included

- `charge.proto` — adds `PlatformCharge.date_added_st` (mirrors `PlatformRefund.date_added_st` so mixed charge+refund timelines can sort off a single time axis).
- `endpoint_list_charges_for_invoice_ids.proto` (new) — used by `ChargeService.list_charges_for_invoice_ids` on master.
- `endpoint_list_charges_for_organization.proto` (new) — used by `ChargeService.list_charges_for_organization` on master.
- `endpoint_get_invoice_guids_for_ids.proto` (new) — used by `ContractService.get_invoice_guids_for_ids` on master.
- `endpoint_start_manual_payment.proto` (new) — used by `ContractService.start_manual_payment` on master (added in getsentry/getsentry#20790).

## Context

Split out from an earlier combined branch. The remaining Pay-Now-loop protos (`release_manual_payment_lock` + modifications to `handle_charge_succeeded` / `capture_charge` / `mark_invoice_paid`) live on branch `andrewmcknight/billing-pay-now-loop-close-protos` and partner with getsentry/getsentry#20833.