### PR TITLE
feat(eap): add sort type to EAP OrderBy messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/snuba/v1/endpoint_get_traces.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_get_traces.proto
@@ -60,8 +60,29 @@ message TraceAttribute {
 // GetTracesRequest lets you query traces with various attributes.
 message GetTracesRequest {
   message OrderBy {
+    // Sort selects which sort order is applied when ordering by a textual
+    // attribute (e.g. KEY_ROOT_SPAN_NAME). It has no effect when ordering by
+    // a numeric attribute such as KEY_ROOT_SPAN_DURATION_MS.
+    enum Sort {
+      // Defaults to SORT_DEFAULT (lexicographic). This keeps the behaviour
+      // backwards compatible when `sort` is left unset.
+      SORT_UNSPECIFIED = 0;
+      // Default lexicographic ordering: values are compared by their Unicode
+      // code points, so e.g. "item10" sorts before "item2".
+      SORT_DEFAULT = 1;
+      // Natural ordering: embedded runs of digits are compared by their
+      // numeric value, so e.g. "item2" sorts before "item10".
+      SORT_NATURAL = 2;
+    }
+
     TraceAttribute.Key key = 1;
     bool descending = 2;
+
+    // The sort order to apply when ordering by a textual attribute. Defaults
+    // to SORT_DEFAULT (lexicographic) when unset, preserving the historical
+    // behaviour. Set to SORT_NATURAL to order alphanumeric values naturally
+    // (e.g. "item2" before "item10"). Ignored for numeric attributes.
+    Sort sort = 3;
   }
 
   // TraceFilter specifies conditions to apply on the items contained in a trace.

--- a/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
@@ -15,8 +15,28 @@ import "sentry_protos/snuba/v1/trace_item_filter.proto";
 // it can also be used for aggregations
 message TraceItemTableRequest {
   message OrderBy {
+    // Sort selects which sort order is applied when ordering by a textual
+    // column. It has no effect when ordering by a numeric column.
+    enum Sort {
+      // Defaults to SORT_DEFAULT (lexicographic). This keeps the behaviour
+      // backwards compatible when `sort` is left unset.
+      SORT_UNSPECIFIED = 0;
+      // Default lexicographic ordering: values are compared by their Unicode
+      // code points, so e.g. "item10" sorts before "item2".
+      SORT_DEFAULT = 1;
+      // Natural ordering: embedded runs of digits are compared by their
+      // numeric value, so e.g. "item2" sorts before "item10".
+      SORT_NATURAL = 2;
+    }
+
     Column column = 1;
     bool descending = 2;
+
+    // The sort order to apply when ordering by a textual column. Defaults to
+    // SORT_DEFAULT (lexicographic) when unset, preserving the historical
+    // behaviour. Set to SORT_NATURAL to order alphanumeric values naturally
+    // (e.g. "item2" before "item10"). Ignored for numeric columns.
+    Sort sort = 3;
   }
 
   RequestMeta meta = 1;

--- a/rust/src/sentry_protos.snuba.v1.rs
+++ b/rust/src/sentry_protos.snuba.v1.rs
@@ -1617,6 +1617,63 @@ pub mod get_traces_request {
         pub key: i32,
         #[prost(bool, tag = "2")]
         pub descending: bool,
+        /// The sort order to apply when ordering by a textual attribute. Defaults
+        /// to SORT_DEFAULT (lexicographic) when unset, preserving the historical
+        /// behaviour. Set to SORT_NATURAL to order alphanumeric values naturally
+        /// (e.g. "item2" before "item10"). Ignored for numeric attributes.
+        #[prost(enumeration = "order_by::Sort", tag = "3")]
+        pub sort: i32,
+    }
+    /// Nested message and enum types in `OrderBy`.
+    pub mod order_by {
+        /// Sort selects which sort order is applied when ordering by a textual
+        /// attribute (e.g. KEY_ROOT_SPAN_NAME). It has no effect when ordering by
+        /// a numeric attribute such as KEY_ROOT_SPAN_DURATION_MS.
+        #[derive(
+            Clone,
+            Copy,
+            Debug,
+            PartialEq,
+            Eq,
+            Hash,
+            PartialOrd,
+            Ord,
+            ::prost::Enumeration
+        )]
+        #[repr(i32)]
+        pub enum Sort {
+            /// Defaults to SORT_DEFAULT (lexicographic). This keeps the behaviour
+            /// backwards compatible when `sort` is left unset.
+            Unspecified = 0,
+            /// Default lexicographic ordering: values are compared by their Unicode
+            /// code points, so e.g. "item10" sorts before "item2".
+            Default = 1,
+            /// Natural ordering: embedded runs of digits are compared by their
+            /// numeric value, so e.g. "item2" sorts before "item10".
+            Natural = 2,
+        }
+        impl Sort {
+            /// String value of the enum field names used in the ProtoBuf definition.
+            ///
+            /// The values are not transformed in any way and thus are considered stable
+            /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+            pub fn as_str_name(&self) -> &'static str {
+                match self {
+                    Self::Unspecified => "SORT_UNSPECIFIED",
+                    Self::Default => "SORT_DEFAULT",
+                    Self::Natural => "SORT_NATURAL",
+                }
+            }
+            /// Creates an enum from field names used in the ProtoBuf definition.
+            pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+                match value {
+                    "SORT_UNSPECIFIED" => Some(Self::Unspecified),
+                    "SORT_DEFAULT" => Some(Self::Default),
+                    "SORT_NATURAL" => Some(Self::Natural),
+                    _ => None,
+                }
+            }
+        }
     }
     /// TraceFilter specifies conditions to apply on the items contained in a trace.
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2294,6 +2351,62 @@ pub mod trace_item_table_request {
         pub column: ::core::option::Option<super::Column>,
         #[prost(bool, tag = "2")]
         pub descending: bool,
+        /// The sort order to apply when ordering by a textual column. Defaults to
+        /// SORT_DEFAULT (lexicographic) when unset, preserving the historical
+        /// behaviour. Set to SORT_NATURAL to order alphanumeric values naturally
+        /// (e.g. "item2" before "item10"). Ignored for numeric columns.
+        #[prost(enumeration = "order_by::Sort", tag = "3")]
+        pub sort: i32,
+    }
+    /// Nested message and enum types in `OrderBy`.
+    pub mod order_by {
+        /// Sort selects which sort order is applied when ordering by a textual
+        /// column. It has no effect when ordering by a numeric column.
+        #[derive(
+            Clone,
+            Copy,
+            Debug,
+            PartialEq,
+            Eq,
+            Hash,
+            PartialOrd,
+            Ord,
+            ::prost::Enumeration
+        )]
+        #[repr(i32)]
+        pub enum Sort {
+            /// Defaults to SORT_DEFAULT (lexicographic). This keeps the behaviour
+            /// backwards compatible when `sort` is left unset.
+            Unspecified = 0,
+            /// Default lexicographic ordering: values are compared by their Unicode
+            /// code points, so e.g. "item10" sorts before "item2".
+            Default = 1,
+            /// Natural ordering: embedded runs of digits are compared by their
+            /// numeric value, so e.g. "item2" sorts before "item10".
+            Natural = 2,
+        }
+        impl Sort {
+            /// String value of the enum field names used in the ProtoBuf definition.
+            ///
+            /// The values are not transformed in any way and thus are considered stable
+            /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+            pub fn as_str_name(&self) -> &'static str {
+                match self {
+                    Self::Unspecified => "SORT_UNSPECIFIED",
+                    Self::Default => "SORT_DEFAULT",
+                    Self::Natural => "SORT_NATURAL",
+                }
+            }
+            /// Creates an enum from field names used in the ProtoBuf definition.
+            pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+                match value {
+                    "SORT_UNSPECIFIED" => Some(Self::Unspecified),
+                    "SORT_DEFAULT" => Some(Self::Default),
+                    "SORT_NATURAL" => Some(Self::Natural),
+                    _ => None,
+                }
+            }
+        }
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]


### PR DESCRIPTION
## Summary

Adds the option to specify the **type of sort** to every EAP `OrderBy` message that didn't already support it:

- `TraceItemTableRequest.OrderBy` (the main EAP table RPC)
- `GetTracesRequest.OrderBy`

Each now carries a `Sort` enum and a `sort` field (tag `3`), mirroring the option already present on `TraceItemAttributeNamesRequest.OrderBy` and `TraceItemAttributeValuesRequest.OrderBy`:

- `SORT_UNSPECIFIED` (0) — treated as `SORT_DEFAULT`.
- `SORT_DEFAULT` (1) — lexicographic ordering (compare by Unicode code points), e.g. `"item10"` before `"item2"`.
- `SORT_NATURAL` (2) — natural ordering (embedded digit runs compared numerically), e.g. `"item2"` before `"item10"`.

The field only affects ordering of textual columns/attributes and is ignored for numeric ones.

## Backwards compatibility

`sort` uses a previously-unused field number (`3`) and defaults to the historical lexicographic behaviour when left unset, so existing callers are unaffected.

## Changes

- Updated `proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto` and `proto/sentry_protos/snuba/v1/endpoint_get_traces.proto`.
- Regenerated the Rust bindings (`rust/src/sentry_protos.snuba.v1.rs`) and refreshed `Cargo.lock`. Python bindings are generated at build time and gitignored, so no committed changes there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SSu2GWvqxaYgR7dDCvQKtm

---
_Generated by [Claude Code](https://claude.ai/code/session_01SSu2GWvqxaYgR7dDCvQKtm)_