### PR TITLE
feat(billing): Add PackageOption/PackageCatalog domain model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.42.0"
+version = "0.42.2"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/services/package/v1/endpoint_get_package_catalog.proto
+++ b/proto/sentry_protos/billing/v1/services/package/v1/endpoint_get_package_catalog.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package sentry_protos.billing.v1.services.package.v1;
+
+import "sentry_protos/billing/v1/services/package/v1/package_catalog.proto";
+
+message GetPackageCatalogRequest {
+  // The package the customer is currently on; the catalog is returned relative
+  // to it. Leave unset for a customer who has not signed up yet, in which case
+  // the catalog for the latest upsell is returned.
+  optional string package_uid = 1;
+}
+
+message GetPackageCatalogResponse {
+  PackageCatalog catalog = 1;
+}

--- a/proto/sentry_protos/billing/v1/services/package/v1/endpoint_get_packages.proto
+++ b/proto/sentry_protos/billing/v1/services/package/v1/endpoint_get_packages.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package sentry_protos.billing.v1.services.package.v1;
+
+import "sentry_protos/billing/v1/services/package/v1/package.proto";
+
+message GetPackagesRequest {
+  // The package uids to fetch. Accepts one or many.
+  repeated string package_uids = 1;
+}
+
+message GetPackagesResponse {
+  // The requested packages, in the same order as the request.
+  repeated PackageConfig package_configs = 1;
+}

--- a/proto/sentry_protos/billing/v1/services/package/v1/package_catalog.proto
+++ b/proto/sentry_protos/billing/v1/services/package/v1/package_catalog.proto
@@ -2,13 +2,10 @@ syntax = "proto3";
 
 package sentry_protos.billing.v1.services.package.v1;
 
-// How a customer can start on a package: sign up on their own, work with
-// sales, or receive it as a grant (e.g. open source / nonprofit).
+// How a customer can start on a package.
 enum AcquisitionMode {
   ACQUISITION_MODE_UNSPECIFIED = 0;
   ACQUISITION_MODE_SELF_SERVE = 1; // customer can sign up on their own
-  ACQUISITION_MODE_SALES = 2; // requires working with sales
-  ACQUISITION_MODE_SPONSORED = 3; // granted (open source / nonprofit)
 }
 
 // A package a customer can subscribe to, such as the Team or Business package.

--- a/proto/sentry_protos/billing/v1/services/package/v1/package_catalog.proto
+++ b/proto/sentry_protos/billing/v1/services/package/v1/package_catalog.proto
@@ -1,0 +1,47 @@
+syntax = "proto3";
+
+package sentry_protos.billing.v1.services.package.v1;
+
+// How a customer can start on a package: sign up on their own, work with
+// sales, or receive it as a grant (e.g. open source / nonprofit).
+enum AcquisitionMode {
+  ACQUISITION_MODE_UNSPECIFIED = 0;
+  ACQUISITION_MODE_SELF_SERVE = 1; // customer can sign up on their own
+  ACQUISITION_MODE_SALES = 2; // requires working with sales
+  ACQUISITION_MODE_SPONSORED = 3; // granted (open source / nonprofit)
+}
+
+// A package a customer can subscribe to, such as the Team or Business package.
+message PackageOption {
+  // Unique identifier for this specific package. Use it with GetPackage to
+  // fetch the package's full details.
+  string uid = 1;
+
+  // The package's display name, e.g. "Team". Shown to customers as-is.
+  string display_name = 2;
+
+  AcquisitionMode acquisition = 3;
+
+  // Which billing terms the package offers, in number of months.
+  // [1] = monthly only, [12] = annual only, [1, 12] = monthly or annual.
+  repeated uint32 supported_month_intervals = 4;
+}
+
+// The set of packages a customer can choose from — the answer to "what can I
+// move to?". Returned relative to the customer's current package, or, when no
+// current package is given, the catalog for the latest upsell.
+message PackageCatalog {
+  // Every package option in the catalog, in the order they should be shown.
+  // Includes the free option, the package the customer is currently on (so it
+  // can be highlighted in context), and enterprise options (which require
+  // talking to sales, flagged via AcquisitionMode).
+  repeated PackageOption packages = 1;
+
+  // uid of the free option within `packages`. Being on it means having no paid
+  // subscription — a distinct state — so it is called out for consumers that
+  // treat it specially.
+  string free_package_uid = 2;
+
+  // uid of the default option within `packages`: the one checkout pre-selects.
+  string default_package_uid = 3;
+}

--- a/proto/sentry_protos/billing/v1/services/package/v1/package_catalog.proto
+++ b/proto/sentry_protos/billing/v1/services/package/v1/package_catalog.proto
@@ -12,19 +12,14 @@ enum AcquisitionMode {
 }
 
 // A package a customer can subscribe to, such as the Team or Business package.
+// Carries only what a catalog needs beyond a bare reference; fetch full details
+// (title, pricing, supported intervals) with GetPackage / GetPackages.
 message PackageOption {
-  // Unique identifier for this specific package. Use it with GetPackage to
-  // fetch the package's full details.
+  // Unique identifier for this package. Resolve it to full details via
+  // GetPackage / GetPackages.
   string uid = 1;
 
-  // The package's display name, e.g. "Team". Shown to customers as-is.
-  string display_name = 2;
-
-  AcquisitionMode acquisition = 3;
-
-  // Which billing terms the package offers, in number of months.
-  // [1] = monthly only, [12] = annual only, [1, 12] = monthly or annual.
-  repeated uint32 supported_month_intervals = 4;
+  AcquisitionMode acquisition = 2;
 }
 
 // The set of packages a customer can choose from — the answer to "what can I

--- a/proto/sentry_protos/billing/v1/services/rate_card/v1/endpoint_get_rate_card_for_package.proto
+++ b/proto/sentry_protos/billing/v1/services/rate_card/v1/endpoint_get_rate_card_for_package.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package sentry_protos.billing.v1.services.rate_card.v1;
+
+import "sentry_protos/billing/v1/services/rate_card/v1/rate_card.proto";
+
+// Build a package's list-price rate card at a billing interval, without a
+// contract. Kept separate from GetRateCardRequest so a request can never mix a
+// contract with an unrelated package — each request is a single valid mode.
+message GetRateCardForPackageRequest {
+  string package_uid = 1;
+  uint32 month_interval = 2;
+}
+
+message GetRateCardForPackageResponse {
+  RateCard rate_card = 1;
+}

--- a/rust/src/sentry_protos.billing.v1.services.package.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.package.v1.rs
@@ -166,3 +166,97 @@ pub struct GetPackageResponse {
     #[prost(message, optional, tag = "1")]
     pub package_config: ::core::option::Option<PackageConfig>,
 }
+/// A package a customer can subscribe to, such as the Team or Business package.
+/// Carries only what a catalog needs beyond a bare reference; fetch full details
+/// (title, pricing, supported intervals) with GetPackage / GetPackages.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct PackageOption {
+    /// Unique identifier for this package. Resolve it to full details via
+    /// GetPackage / GetPackages.
+    #[prost(string, tag = "1")]
+    pub uid: ::prost::alloc::string::String,
+    #[prost(enumeration = "AcquisitionMode", tag = "2")]
+    pub acquisition: i32,
+}
+/// The set of packages a customer can choose from — the answer to "what can I
+/// move to?". Returned relative to the customer's current package, or, when no
+/// current package is given, the catalog for the latest upsell.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PackageCatalog {
+    /// Every package option in the catalog, in the order they should be shown.
+    /// Includes the free option, the package the customer is currently on (so it
+    /// can be highlighted in context), and enterprise options (which require
+    /// talking to sales, flagged via AcquisitionMode).
+    #[prost(message, repeated, tag = "1")]
+    pub packages: ::prost::alloc::vec::Vec<PackageOption>,
+    /// uid of the free option within `packages`. Being on it means having no paid
+    /// subscription — a distinct state — so it is called out for consumers that
+    /// treat it specially.
+    #[prost(string, tag = "2")]
+    pub free_package_uid: ::prost::alloc::string::String,
+    /// uid of the default option within `packages`: the one checkout pre-selects.
+    #[prost(string, tag = "3")]
+    pub default_package_uid: ::prost::alloc::string::String,
+}
+/// How a customer can start on a package: sign up on their own, work with
+/// sales, or receive it as a grant (e.g. open source / nonprofit).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum AcquisitionMode {
+    Unspecified = 0,
+    /// customer can sign up on their own
+    SelfServe = 1,
+    /// requires working with sales
+    Sales = 2,
+    /// granted (open source / nonprofit)
+    Sponsored = 3,
+}
+impl AcquisitionMode {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Self::Unspecified => "ACQUISITION_MODE_UNSPECIFIED",
+            Self::SelfServe => "ACQUISITION_MODE_SELF_SERVE",
+            Self::Sales => "ACQUISITION_MODE_SALES",
+            Self::Sponsored => "ACQUISITION_MODE_SPONSORED",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "ACQUISITION_MODE_UNSPECIFIED" => Some(Self::Unspecified),
+            "ACQUISITION_MODE_SELF_SERVE" => Some(Self::SelfServe),
+            "ACQUISITION_MODE_SALES" => Some(Self::Sales),
+            "ACQUISITION_MODE_SPONSORED" => Some(Self::Sponsored),
+            _ => None,
+        }
+    }
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct GetPackageCatalogRequest {
+    /// The package the customer is currently on; the catalog is returned relative
+    /// to it. Leave unset for a customer who has not signed up yet, in which case
+    /// the catalog for the latest upsell is returned.
+    #[prost(string, optional, tag = "1")]
+    pub package_uid: ::core::option::Option<::prost::alloc::string::String>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetPackageCatalogResponse {
+    #[prost(message, optional, tag = "1")]
+    pub catalog: ::core::option::Option<PackageCatalog>,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct GetPackagesRequest {
+    /// The package uids to fetch. Accepts one or many.
+    #[prost(string, repeated, tag = "1")]
+    pub package_uids: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetPackagesResponse {
+    /// The requested packages, in the same order as the request.
+    #[prost(message, repeated, tag = "1")]
+    pub package_configs: ::prost::alloc::vec::Vec<PackageConfig>,
+}

--- a/rust/src/sentry_protos.billing.v1.services.package.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.package.v1.rs
@@ -198,18 +198,13 @@ pub struct PackageCatalog {
     #[prost(string, tag = "3")]
     pub default_package_uid: ::prost::alloc::string::String,
 }
-/// How a customer can start on a package: sign up on their own, work with
-/// sales, or receive it as a grant (e.g. open source / nonprofit).
+/// How a customer can start on a package.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum AcquisitionMode {
     Unspecified = 0,
     /// customer can sign up on their own
     SelfServe = 1,
-    /// requires working with sales
-    Sales = 2,
-    /// granted (open source / nonprofit)
-    Sponsored = 3,
 }
 impl AcquisitionMode {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -220,8 +215,6 @@ impl AcquisitionMode {
         match self {
             Self::Unspecified => "ACQUISITION_MODE_UNSPECIFIED",
             Self::SelfServe => "ACQUISITION_MODE_SELF_SERVE",
-            Self::Sales => "ACQUISITION_MODE_SALES",
-            Self::Sponsored => "ACQUISITION_MODE_SPONSORED",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -229,8 +222,6 @@ impl AcquisitionMode {
         match value {
             "ACQUISITION_MODE_UNSPECIFIED" => Some(Self::Unspecified),
             "ACQUISITION_MODE_SELF_SERVE" => Some(Self::SelfServe),
-            "ACQUISITION_MODE_SALES" => Some(Self::Sales),
-            "ACQUISITION_MODE_SPONSORED" => Some(Self::Sponsored),
             _ => None,
         }
     }

--- a/rust/src/sentry_protos.billing.v1.services.rate_card.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.rate_card.v1.rs
@@ -78,3 +78,18 @@ pub struct GetRateCardResponse {
     #[prost(message, optional, tag = "1")]
     pub rate_card: ::core::option::Option<RateCard>,
 }
+/// Build a package's list-price rate card at a billing interval, without a
+/// contract. Kept separate from GetRateCardRequest so a request can never mix a
+/// contract with an unrelated package — each request is a single valid mode.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct GetRateCardForPackageRequest {
+    #[prost(string, tag = "1")]
+    pub package_uid: ::prost::alloc::string::String,
+    #[prost(uint32, tag = "2")]
+    pub month_interval: u32,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetRateCardForPackageResponse {
+    #[prost(message, optional, tag = "1")]
+    pub rate_card: ::core::option::Option<RateCard>,
+}


### PR DESCRIPTION
Billing Platform domain-model protos for the package catalog, plus a package-scoped rate card endpoint.

- `PackageOption` / `PackageCatalog` and the `GetPackageCatalog` / `GetPackages` endpoints — the catalog of packages a customer can move to, and how to resolve options to their `PackageConfig`s. `AcquisitionMode` is `UNSPECIFIED` / `SELF_SERVE`.
- `GetRateCardForPackage` — a new endpoint (`package_uid` + `month_interval`) that builds a package's list-price rate card **without a contract**. `GetRateCardRequest` is left untouched, so this is purely additive — no breaking change.
