### PR TITLE
feat(billing): add charge to CaptureChargeResponse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.41.1"
+version = "0.42.0"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/services/charge/v1/endpoint_capture_charge.proto
+++ b/proto/sentry_protos/billing/v1/services/charge/v1/endpoint_capture_charge.proto
@@ -5,6 +5,7 @@ package sentry_protos.billing.v1.services.charge.v1;
 import "google/protobuf/timestamp.proto";
 import "sentry_protos/billing/v1/common/v1/payment_config.proto";
 import "sentry_protos/billing/v1/common/v1/stripe_charge.proto";
+import "sentry_protos/billing/v1/services/charge/v1/charge.proto";
 
 // How the charge should be executed against the payment provider.
 enum ChargeMethod {
@@ -38,4 +39,11 @@ message CaptureChargeRequest {
 message CaptureChargeResponse {
   bool paid = 1;
   optional string failure_code = 2;
+  // The persisted PlatformCharge row produced (or updated) by this call.
+  // Unset when the charge_method does not persist a row (e.g. legacy
+  // paths that only report paid/failure_code without a stored charge).
+  // Callers that need the full Charge projection can consume this field
+  // directly instead of following capture_charge with a separate
+  // update_charge round-trip.
+  optional PlatformCharge charge = 3;
 }

--- a/rust/src/sentry_protos.billing.v1.services.charge.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.charge.v1.rs
@@ -98,12 +98,20 @@ pub struct CaptureChargeRequest {
         super::super::super::common::v1::StripeCharge,
     >,
 }
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CaptureChargeResponse {
     #[prost(bool, tag = "1")]
     pub paid: bool,
     #[prost(string, optional, tag = "2")]
     pub failure_code: ::core::option::Option<::prost::alloc::string::String>,
+    /// The persisted PlatformCharge row produced (or updated) by this call.
+    /// Unset when the charge_method does not persist a row (e.g. legacy
+    /// paths that only report paid/failure_code without a stored charge).
+    /// Callers that need the full Charge projection can consume this field
+    /// directly instead of following capture_charge with a separate
+    /// update_charge round-trip.
+    #[prost(message, optional, tag = "3")]
+    pub charge: ::core::option::Option<PlatformCharge>,
 }
 /// How the charge should be executed against the payment provider.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]


### PR DESCRIPTION
## Summary

- Adds an optional `PlatformCharge` field on `CaptureChargeResponse` (tag 3) so callers of `capture_charge` can consume the persisted charge row directly.
- Mirrors the shape of `UpdateChargeResponse.charge` (same optional `PlatformCharge`), so downstream code paths that need the full Charge projection have one uniform surface.
- Backward compatible: existing producers that don't set the field leave it unset; existing consumers that don't read the field are unaffected.

## Motivation

In getsentry PR [#20833](https://github.com/getsentry/getsentry/pull/20833), the platform Pay-Now webhook path does:

```py
capture_response = ChargeService().capture_charge(CaptureChargeRequest(...))
update_response = ChargeService().update_charge(UpdateChargeRequest(stripe_charge=...))
charge = update_response.charge
```

The second call exists only because `CaptureChargeResponse` doesn't currently carry the persisted charge -- so we have to round-trip through `update_charge` to get the `PlatformCharge` proto the downstream code (e.g. `charge.HasField("invoice_id")`, `charge.paid`) needs.

Reviewer feedback on that PR asked why we call `update` immediately after `capture` given we already provided the `stripe_charge` to `capture`; with this proto change the getsentry side can consume `capture_response.charge` and drop the redundant `update_charge` round-trip.

## Test plan

- [ ] `make build-py` produces `endpoint_capture_charge_pb2.pyi` with the new field
- [ ] Import + descriptor check: `CaptureChargeResponse.DESCRIPTOR.fields` includes `charge` at tag 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)