### PR TITLE
ref: Add reserved line item spend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.41.1"
+version = "0.42.0"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/services/usage_pricer/v1/endpoint_usage_pricer.proto
+++ b/proto/sentry_protos/billing/v1/services/usage_pricer/v1/endpoint_usage_pricer.proto
@@ -62,6 +62,11 @@ message LineItemUsageSummary {
   // both reserved and PAYG usage (in the line item's units). Unlike `quantity`,
   // this is not reduced by the reserved amount.
   uint64 total_quantity = 6;
+
+  // Cents this line item drew from its shared reserved budget in the billing
+  // period. Only set for members of a shared reserved-budget pool (e.g. Seer);
+  // 0 for line items without a reserved budget.
+  uint64 reserved_spend_cents = 7;
 }
 
 message SharedLineItemUsageSummary {

--- a/rust/src/sentry_protos.billing.v1.services.usage_pricer.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.usage_pricer.v1.rs
@@ -115,6 +115,11 @@ pub struct LineItemUsageSummary {
     /// this is not reduced by the reserved amount.
     #[prost(uint64, tag = "6")]
     pub total_quantity: u64,
+    /// Cents this line item drew from its shared reserved budget in the billing
+    /// period. Only set for members of a shared reserved-budget pool (e.g. Seer);
+    /// 0 for line items without a reserved budget.
+    #[prost(uint64, tag = "7")]
+    pub reserved_spend_cents: u64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SharedLineItemUsageSummary {


### PR DESCRIPTION
The subscription page needs to know how much spend was used for each contributor of a reserved budget pool. This makes that visible through the usage pricer interface