### PR TITLE
chore(billing-platform): Add is_sponsored field to PackageConfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.42.2"
+version = "0.43.0"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/services/package/v1/package.proto
+++ b/proto/sentry_protos/billing/v1/services/package/v1/package.proto
@@ -94,4 +94,7 @@ message PackageConfig {
 
   // Whether the package has pay-as-you-go (PAYG) modes.
   bool has_payg_modes = 12;
+
+  // similar to is_enterprise, but for sponsored packages.
+  bool is_sponsored = 13;
 }

--- a/rust/src/sentry_protos.billing.v1.services.package.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.package.v1.rs
@@ -155,6 +155,9 @@ pub struct PackageConfig {
     /// Whether the package has pay-as-you-go (PAYG) modes.
     #[prost(bool, tag = "12")]
     pub has_payg_modes: bool,
+    /// similar to is_enterprise, but for sponsored packages.
+    #[prost(bool, tag = "13")]
+    pub is_sponsored: bool,
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct GetPackageRequest {


### PR DESCRIPTION
This will be used to display certain things in the UI and the EngagementService will use it to gate trial eligibility