### PR TITLE
feat(billing-platform): Add contract add_user_configs endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.44.1"
+version = "0.44.2"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_add_user_configs.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_add_user_configs.proto
@@ -1,0 +1,32 @@
+syntax = "proto3";
+
+package sentry_protos.billing.v1.services.contract.v1;
+
+import "sentry_protos/billing/v1/common/v1/pending_change.proto";
+import "sentry_protos/billing/v1/services/contract/v1/endpoint_apply_immediate_user_config.proto";
+import "sentry_protos/billing/v1/services/contract/v1/pricing_config.proto";
+import "sentry_protos/billing/v1/services/pending_change/v1/endpoint_add_pending_user_config.proto";
+
+// Applies a batch of user-config changes to a contract in one call. The
+// `immediate` configs take effect on the contract now; the `pending` configs
+// are staged for the next billing period. Grouping both in a single request
+// lets the contract service apply them atomically, so a checkout change that
+// resolves to both an immediate and a pending part cannot land half-applied.
+message AddUserConfigsRequest {
+  uint64 contract_id = 1;
+
+  // Configs applied to the contract immediately.
+  repeated UserConfig immediate = 2;
+
+  // Configs staged to take effect at the next billing period. Mirrors the shape
+  // add_pending_user_config accepts so they can be forwarded without conversion.
+  repeated sentry_protos.billing.v1.common.v1.PendingUserConfig pending = 3;
+}
+
+message AddUserConfigsResponse {
+  // Per-config results, in the same order as the request's `immediate` list.
+  repeated ApplyImmediateUserConfigResponse immediate = 1;
+
+  // Per-config results, in the same order as the request's `pending` list.
+  repeated sentry_protos.billing.v1.services.pending_change.v1.AddPendingUserConfigResponse pending = 2;
+}

--- a/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_apply_immediate_user_config.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_apply_immediate_user_config.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+
+package sentry_protos.billing.v1.services.contract.v1;
+
+import "sentry_protos/billing/v1/services/contract/v1/pricing_config.proto";
+
+// Applies a single user config to a contract immediately, repointing the
+// contract's live parameters. Used internally by add_user_configs (there is no
+// standalone service endpoint), mirroring how add_pending_user_config stages a
+// single pending config.
+message ApplyImmediateUserConfigRequest {
+  uint64 contract_id = 1;
+  UserConfig user_config = 2;
+}
+
+message ApplyImmediateUserConfigResponse {
+  // True when a new parameter was added for the config's scope; false when an
+  // existing parameter was repointed.
+  bool created = 1;
+}

--- a/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
@@ -563,6 +563,54 @@ pub struct Contract {
     #[prost(message, optional, tag = "3")]
     pub pricing_config: ::core::option::Option<PricingConfig>,
 }
+/// Applies a single user config to a contract immediately, repointing the
+/// contract's live parameters. Used internally by add_user_configs (there is no
+/// standalone service endpoint), mirroring how add_pending_user_config stages a
+/// single pending config.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ApplyImmediateUserConfigRequest {
+    #[prost(uint64, tag = "1")]
+    pub contract_id: u64,
+    #[prost(message, optional, tag = "2")]
+    pub user_config: ::core::option::Option<UserConfig>,
+}
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ApplyImmediateUserConfigResponse {
+    /// True when a new parameter was added for the config's scope; false when an
+    /// existing parameter was repointed.
+    #[prost(bool, tag = "1")]
+    pub created: bool,
+}
+/// Applies a batch of user-config changes to a contract in one call. The
+/// `immediate` configs take effect on the contract now; the `pending` configs
+/// are staged for the next billing period. Grouping both in a single request
+/// lets the contract service apply them atomically, so a checkout change that
+/// resolves to both an immediate and a pending part cannot land half-applied.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AddUserConfigsRequest {
+    #[prost(uint64, tag = "1")]
+    pub contract_id: u64,
+    /// Configs applied to the contract immediately.
+    #[prost(message, repeated, tag = "2")]
+    pub immediate: ::prost::alloc::vec::Vec<UserConfig>,
+    /// Configs staged to take effect at the next billing period. Mirrors the shape
+    /// add_pending_user_config accepts so they can be forwarded without conversion.
+    #[prost(message, repeated, tag = "3")]
+    pub pending: ::prost::alloc::vec::Vec<
+        super::super::super::common::v1::PendingUserConfig,
+    >,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AddUserConfigsResponse {
+    /// Per-config results, in the same order as the request's `immediate` list.
+    #[prost(message, repeated, tag = "1")]
+    pub immediate: ::prost::alloc::vec::Vec<ApplyImmediateUserConfigResponse>,
+    /// Per-config results, in the same order as the request's `pending` list.
+    #[prost(message, repeated, tag = "2")]
+    pub pending: ::prost::alloc::vec::Vec<
+        super::super::pending_change::v1::AddPendingUserConfigResponse,
+    >,
+}
 /// Atomically claims an unpaid PlatformInvoice for charging by stamping
 /// manual_payment_started_at. The same column is claimed by both the
 /// manual Pay Now flow (via this endpoint) and the automated invoicing


### PR DESCRIPTION
Adds `AddUserConfigs` to the contract service: apply a batch of **immediate** and **pending** user-config changes to a contract in one call so a checkout change that resolves to both parts can be applied atomically by the contract service.

- `immediate`: `repeated UserConfig` — applied to the contract now.
- `pending`: `repeated common.v1.PendingUserConfig` — staged for the next period. Reuses the same shape `add_pending_user_config` accepts, so configs forward without conversion.
- Response returns per-config results for both lists (`ApplyImmediateUserConfigResponse` / `AddPendingUserConfigResponse`).

Also adds the internal `ApplyImmediateUserConfig` request/response used by `add_user_configs`.

Supports the billing-platform self-serve checkout write path in getsentry (consumer PR to follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)