### PR TITLE
ref(billing): PreviewNextInvoiceRequest gains cancel + partner hints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.44.2"
+version = "0.45.0"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/services/invoicer/v1/endpoint_preview_next_invoice.proto
+++ b/proto/sentry_protos/billing/v1/services/invoicer/v1/endpoint_preview_next_invoice.proto
@@ -11,6 +11,8 @@ import "sentry_protos/billing/v1/services/contract/v1/invoice.proto";
 // balance_change line items), and sales tax.
 message PreviewNextInvoiceRequest {
   uint64 contract_id = 1;
+  bool cancel_at_period_end = 2;
+  bool is_self_serve_partner = 3;
 }
 
 message PreviewNextInvoiceResponse {

--- a/rust/src/sentry_protos.billing.v1.services.invoicer.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.invoicer.v1.rs
@@ -165,6 +165,10 @@ pub struct MaterializePlatformChargeResponse {
 pub struct PreviewNextInvoiceRequest {
     #[prost(uint64, tag = "1")]
     pub contract_id: u64,
+    #[prost(bool, tag = "2")]
+    pub cancel_at_period_end: bool,
+    #[prost(bool, tag = "3")]
+    pub is_self_serve_partner: bool,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PreviewNextInvoiceResponse {


### PR DESCRIPTION
Some bot comments pointed out that the original changes in https://github.com/getsentry/getsentry/pull/20791 didn't account for these data. Local validation showed that twiddling the cancel bit changed the value in the next bill box. Claude is telling me there's no good way to test the partner data, although I could probably mock it but haven't tested it yet; maybe it can be removed from here.

There are some pieces of data used in the legacy next bill preview that weren't yet transmitted in the RPC message we're using, and these still aren't represented in platform models so need to currently be derived from Subscriptions.

It looks like maybe the renew data would be done as part of https://linear.app/getsentry/issue/REVENG-266/add-platform-plan-change-compute-service-preview-apply and the self serve partner data from https://linear.app/getsentry/issue/REVENG-228/expand-billing-platform-supportsondemand-to-cover-self-serve-partners.