### PR TITLE
feat(billing): Add common retention policy types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/common/v1/retention.proto
+++ b/proto/sentry_protos/billing/v1/common/v1/retention.proto
@@ -4,28 +4,34 @@ package sentry_protos.billing.v1.common.v1;
 
 import "sentry_protos/billing/v1/data_category.proto";
 
-// The complete retention settings for a data category.
+// Retention settings for one data category.
 //
-// These are complete package/common settings, not sparse override semantics.
+// A package uses this message for a complete policy. Do not use this message
+// for sparse updates or overrides. Services validate categories, apply
+// precedence, preserve legacy behavior, and calculate effective retention.
 message RetentionSettings {
-  // Standard/full-fidelity retention in calendar days. Must be greater than zero.
+  // The number of calendar days to retain standard data. The value must be
+  // greater than zero.
   uint32 standard_days = 1;
 
-  // Retention for a distinct downsampled representation in calendar days.
+  // The number of calendar days to retain downsampled data.
   //
-  // Absence means the category has no distinct downsampled representation. A
-  // present zero is a package compatibility value interpreted by the retention
-  // resolver as the effective standard retention. A positive value is a
-  // concrete downsampled retention duration.
+  // If this field is absent, the category has no separate downsampled data. If
+  // the value is zero, the resolver uses the effective standard retention. This
+  // value preserves legacy behavior. A positive value is a concrete duration.
   optional uint32 downsampled_days = 2;
 }
 
-// Associates complete retention settings with a billing data category.
+// Complete retention settings for one billing data category.
+//
+// Retention is keyed by billing data category, not by line item or SKU. A line
+// item can bill more than one category. A category can be billed by more than
+// one line item. Some line items have no retention. A shared pool bills no
+// single category. Do not read a category from a line item.
 message DataCategoryRetention {
-  // The supported billing data category. DATA_CATEGORY_UNSPECIFIED and
-  // DATA_CATEGORY_UNKNOWN are invalid.
+  // Do not use DATA_CATEGORY_UNSPECIFIED or DATA_CATEGORY_UNKNOWN.
   sentry_protos.billing.v1.DataCategory category = 1;
 
-  // The category's retention settings. Required by the domain model.
+  // The category retention settings. This message is required.
   RetentionSettings settings = 2;
 }

--- a/proto/sentry_protos/billing/v1/common/v1/retention.proto
+++ b/proto/sentry_protos/billing/v1/common/v1/retention.proto
@@ -1,0 +1,31 @@
+syntax = "proto3";
+
+package sentry_protos.billing.v1.common.v1;
+
+import "sentry_protos/billing/v1/data_category.proto";
+
+// The complete retention settings for a data category.
+//
+// These are complete package/common settings, not sparse override semantics.
+message RetentionSettings {
+  // Standard/full-fidelity retention in calendar days. Must be greater than zero.
+  uint32 standard_days = 1;
+
+  // Retention for a distinct downsampled representation in calendar days.
+  //
+  // Absence means the category has no distinct downsampled representation. A
+  // present zero is a package compatibility value interpreted by the retention
+  // resolver as the effective standard retention. A positive value is a
+  // concrete downsampled retention duration.
+  optional uint32 downsampled_days = 2;
+}
+
+// Associates complete retention settings with a billing data category.
+message DataCategoryRetention {
+  // The supported billing data category. DATA_CATEGORY_UNSPECIFIED and
+  // DATA_CATEGORY_UNKNOWN are invalid.
+  sentry_protos.billing.v1.DataCategory category = 1;
+
+  // The category's retention settings. Required by the domain model.
+  RetentionSettings settings = 2;
+}

--- a/py/tests/test_billing_v1.py
+++ b/py/tests/test_billing_v1.py
@@ -51,6 +51,10 @@ from sentry_protos.billing.v1.common.v1.billable_metric_pb2 import (
     Operator,
 )
 from sentry_protos.billing.v1.common.v1.billing_interval_pb2 import BillingInterval
+from sentry_protos.billing.v1.common.v1.retention_pb2 import (
+    DataCategoryRetention,
+    RetentionSettings,
+)
 from sentry_protos.billing.v1.services.package.v1.package_pb2 import PackageConfig
 from sentry_protos.billing.v1.services.package.v1.endpoint_get_package_pb2 import (
     GetPackageRequest,
@@ -676,5 +680,51 @@ def test_upsert_account_status_response():
 
     default_response = UpsertAccountStatusResponse()
     assert default_response.updated is False
+
+
+def test_retention_settings_without_downsampled_representation():
+    settings = RetentionSettings(standard_days=30)
+
+    assert settings.standard_days == 30
+    assert not settings.HasField("downsampled_days")
+
+
+def test_retention_settings_downsampled_days_presence():
+    unset = RetentionSettings(standard_days=30)
+    assert not unset.HasField("downsampled_days")
+
+    configured = RetentionSettings(standard_days=30, downsampled_days=90)
+    assert configured.HasField("downsampled_days")
+    assert configured.downsampled_days == 90
+
+    # Complete package settings preserve the legacy compatibility value: a
+    # present zero means the distinct downsampled representation uses effective
+    # standard retention. The resolver interprets it; effective output never
+    # exposes zero.
+    compatibility = RetentionSettings(standard_days=30, downsampled_days=0)
+    assert compatibility.HasField("downsampled_days")
+    assert compatibility.downsampled_days == 0
+
+
+def test_data_category_retention_roundtrip():
+    retention = DataCategoryRetention(
+        category=DataCategory.DATA_CATEGORY_SPAN,
+        settings=RetentionSettings(standard_days=30, downsampled_days=0),
+    )
+
+    assert retention.category == DataCategory.DATA_CATEGORY_SPAN
+    assert retention.HasField("settings")
+    assert retention.settings.standard_days == 30
+    assert retention.settings.HasField("downsampled_days")
+    assert retention.settings.downsampled_days == 0
+
+    parsed = DataCategoryRetention()
+    parsed.ParseFromString(retention.SerializeToString())
+
+    assert parsed == retention
+    assert parsed.HasField("settings")
+    assert parsed.settings.standard_days == 30
+    assert parsed.settings.HasField("downsampled_days")
+    assert parsed.settings.downsampled_days == 0
 
 

--- a/rust/src/sentry_protos.billing.v1.common.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.common.v1.rs
@@ -440,31 +440,37 @@ pub struct TieredPricingRate {
     #[prost(message, repeated, tag = "1")]
     pub tiers: ::prost::alloc::vec::Vec<PricingTier>,
 }
-/// The complete retention settings for a data category.
+/// Retention settings for one data category.
 ///
-/// These are complete package/common settings, not sparse override semantics.
+/// A package uses this message for a complete policy. Do not use this message
+/// for sparse updates or overrides. Services validate categories, apply
+/// precedence, preserve legacy behavior, and calculate effective retention.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct RetentionSettings {
-    /// Standard/full-fidelity retention in calendar days. Must be greater than zero.
+    /// The number of calendar days to retain standard data. The value must be
+    /// greater than zero.
     #[prost(uint32, tag = "1")]
     pub standard_days: u32,
-    /// Retention for a distinct downsampled representation in calendar days.
+    /// The number of calendar days to retain downsampled data.
     ///
-    /// Absence means the category has no distinct downsampled representation. A
-    /// present zero is a package compatibility value interpreted by the retention
-    /// resolver as the effective standard retention. A positive value is a
-    /// concrete downsampled retention duration.
+    /// If this field is absent, the category has no separate downsampled data. If
+    /// the value is zero, the resolver uses the effective standard retention. This
+    /// value preserves legacy behavior. A positive value is a concrete duration.
     #[prost(uint32, optional, tag = "2")]
     pub downsampled_days: ::core::option::Option<u32>,
 }
-/// Associates complete retention settings with a billing data category.
+/// Complete retention settings for one billing data category.
+///
+/// Retention is keyed by billing data category, not by line item or SKU. A line
+/// item can bill more than one category. A category can be billed by more than
+/// one line item. Some line items have no retention. A shared pool bills no
+/// single category. Do not read a category from a line item.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct DataCategoryRetention {
-    /// The supported billing data category. DATA_CATEGORY_UNSPECIFIED and
-    /// DATA_CATEGORY_UNKNOWN are invalid.
+    /// Do not use DATA_CATEGORY_UNSPECIFIED or DATA_CATEGORY_UNKNOWN.
     #[prost(enumeration = "super::super::DataCategory", tag = "1")]
     pub category: i32,
-    /// The category's retention settings. Required by the domain model.
+    /// The category retention settings. This message is required.
     #[prost(message, optional, tag = "2")]
     pub settings: ::core::option::Option<RetentionSettings>,
 }

--- a/rust/src/sentry_protos.billing.v1.common.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.common.v1.rs
@@ -440,6 +440,34 @@ pub struct TieredPricingRate {
     #[prost(message, repeated, tag = "1")]
     pub tiers: ::prost::alloc::vec::Vec<PricingTier>,
 }
+/// The complete retention settings for a data category.
+///
+/// These are complete package/common settings, not sparse override semantics.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct RetentionSettings {
+    /// Standard/full-fidelity retention in calendar days. Must be greater than zero.
+    #[prost(uint32, tag = "1")]
+    pub standard_days: u32,
+    /// Retention for a distinct downsampled representation in calendar days.
+    ///
+    /// Absence means the category has no distinct downsampled representation. A
+    /// present zero is a package compatibility value interpreted by the retention
+    /// resolver as the effective standard retention. A positive value is a
+    /// concrete downsampled retention duration.
+    #[prost(uint32, optional, tag = "2")]
+    pub downsampled_days: ::core::option::Option<u32>,
+}
+/// Associates complete retention settings with a billing data category.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct DataCategoryRetention {
+    /// The supported billing data category. DATA_CATEGORY_UNSPECIFIED and
+    /// DATA_CATEGORY_UNKNOWN are invalid.
+    #[prost(enumeration = "super::super::DataCategory", tag = "1")]
+    pub category: i32,
+    /// The category's retention settings. Required by the domain model.
+    #[prost(message, optional, tag = "2")]
+    pub settings: ::core::option::Option<RetentionSettings>,
+}
 /// Card payment method details.
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Card {

--- a/rust/tests/codegen_test.rs
+++ b/rust/tests/codegen_test.rs
@@ -12,6 +12,7 @@ use prost::Message;
 // These `use` statements are compile-time tests. If a module path is
 // wrong or a type doesn't exist, the test file won't compile.
 
+use sentry_protos::billing::v1::common::v1::{DataCategoryRetention, RetentionSettings};
 use sentry_protos::billing::v1::DataCategory;
 use sentry_protos::billing::v1::Date;
 use sentry_protos::billing::v1::SeatCategory;
@@ -105,4 +106,37 @@ fn default_messages_roundtrip() {
     assert_roundtrip(&GetUsageRequest::default());
     assert_roundtrip(&GetUsageResponse::default());
     assert_roundtrip(&Contract::default());
+}
+
+#[test]
+fn roundtrip_retention_with_downsampled_days() {
+    assert_roundtrip(&DataCategoryRetention {
+        category: DataCategory::Span as i32,
+        settings: Some(RetentionSettings {
+            standard_days: 30,
+            downsampled_days: Some(90),
+        }),
+    });
+}
+
+#[test]
+fn roundtrip_retention_with_downsampled_compatibility_value() {
+    assert_roundtrip(&DataCategoryRetention {
+        category: DataCategory::Transaction as i32,
+        settings: Some(RetentionSettings {
+            standard_days: 30,
+            downsampled_days: Some(0),
+        }),
+    });
+}
+
+#[test]
+fn roundtrip_retention_without_downsampled_representation() {
+    assert_roundtrip(&DataCategoryRetention {
+        category: DataCategory::Error as i32,
+        settings: Some(RetentionSettings {
+            standard_days: 90,
+            downsampled_days: None,
+        }),
+    });
 }


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/REVENG-333/introduce-retention-protos

This introduces common and re-usable retention protos that'll be used in:
- contract (customer specific retention overrides)
- package (default retentions for a given pricing package)

Prior art from legacy billing system that's ported into new billing platform world:
- `TieredPlanItem.retention` and `TieredPlanItem.downsampled_event_retention`
https://github.com/getsentry/getsentry/blob/b9f4cddb1d463c5f56083cad5b1201f165f52ccd/getsentry/billing/plans/tiered_plan_item.py#L38-L39
- `BillingMetricHistory.retention_days` and `BillingMetricHistory.retention_days_downsampled` https://github.com/getsentry/getsentry/blob/b9f4cddb1d463c5f56083cad5b1201f165f52ccd/getsentry/models/billingmetrichistory.py#L491-L493
