### PR TITLE
feat(billing): Add retention to pricing package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/services/package/v1/package.proto
+++ b/proto/sentry_protos/billing/v1/services/package/v1/package.proto
@@ -6,6 +6,7 @@ import "sentry_protos/billing/v1/common/v1/billing_interval.proto";
 import "sentry_protos/billing/v1/common/v1/flexible_price.proto";
 import "sentry_protos/billing/v1/common/v1/line_item_details.proto";
 import "sentry_protos/billing/v1/common/v1/pricing_tier.proto";
+import "sentry_protos/billing/v1/common/v1/retention.proto";
 
 message LineItemConfig {
   // Base price for the line item (upgraded reserved volumes or add-on activation fees)
@@ -94,4 +95,9 @@ message PackageConfig {
 
   // Whether the package has pay-as-you-go (PAYG) modes.
   bool has_payg_modes = 12;
+
+  // Default retention settings for this package.
+  // Each entry uses a billing data category.
+  // A category can occur only once.
+  repeated sentry_protos.billing.v1.common.v1.DataCategoryRetention retention_defaults = 14;
 }

--- a/py/tests/test_billing_v1.py
+++ b/py/tests/test_billing_v1.py
@@ -409,6 +409,52 @@ def test_package_config_with_billing_interval():
     assert annual_package.billing_interval == BillingInterval.BILLING_INTERVAL_ANNUAL_BASE_MONTHLY_PAYG
 
 
+def test_package_config_with_retention_defaults():
+    package = PackageConfig(
+        uid="business",
+        retention_defaults=[
+            DataCategoryRetention(
+                category=DataCategory.DATA_CATEGORY_SPAN,
+                settings=RetentionSettings(standard_days=30, downsampled_days=396),
+            ),
+            DataCategoryRetention(
+                category=DataCategory.DATA_CATEGORY_TRANSACTION,
+                settings=RetentionSettings(standard_days=30, downsampled_days=0),
+            ),
+            DataCategoryRetention(
+                category=DataCategory.DATA_CATEGORY_ERROR,
+                settings=RetentionSettings(standard_days=90),
+            ),
+        ],
+    )
+
+    assert len(package.retention_defaults) == 3
+
+    spans = package.retention_defaults[0]
+    assert spans.category == DataCategory.DATA_CATEGORY_SPAN
+    assert spans.HasField("settings")
+    assert spans.settings.standard_days == 30
+    assert spans.settings.HasField("downsampled_days")
+    assert spans.settings.downsampled_days == 396
+
+    transactions = package.retention_defaults[1]
+    assert transactions.category == DataCategory.DATA_CATEGORY_TRANSACTION
+    assert transactions.settings.standard_days == 30
+    assert transactions.settings.HasField("downsampled_days")
+    assert transactions.settings.downsampled_days == 0
+
+    errors = package.retention_defaults[2]
+    assert errors.category == DataCategory.DATA_CATEGORY_ERROR
+    assert errors.settings.standard_days == 90
+    assert not errors.settings.HasField("downsampled_days")
+
+    parsed = PackageConfig()
+    parsed.ParseFromString(package.SerializeToString())
+
+    assert parsed == package
+    assert len(parsed.retention_defaults) == 3
+
+
 def test_get_package_request():
     request = GetPackageRequest(package_uid="pkg_monthly_123")
     assert request.package_uid == "pkg_monthly_123"

--- a/rust/src/sentry_protos.billing.v1.services.package.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.package.v1.rs
@@ -155,6 +155,13 @@ pub struct PackageConfig {
     /// Whether the package has pay-as-you-go (PAYG) modes.
     #[prost(bool, tag = "12")]
     pub has_payg_modes: bool,
+    /// Default retention settings for this package.
+    /// Each entry uses a billing data category.
+    /// A category can occur only once.
+    #[prost(message, repeated, tag = "14")]
+    pub retention_defaults: ::prost::alloc::vec::Vec<
+        super::super::super::common::v1::DataCategoryRetention,
+    >,
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct GetPackageRequest {

--- a/rust/tests/codegen_test.rs
+++ b/rust/tests/codegen_test.rs
@@ -18,6 +18,7 @@ use sentry_protos::billing::v1::Date;
 use sentry_protos::billing::v1::SeatCategory;
 use sentry_protos::billing::v1::UsageData;
 use sentry_protos::billing::v1::services::contract::v1::{Contract, GetContractRequest};
+use sentry_protos::billing::v1::services::package::v1::PackageConfig;
 use sentry_protos::billing::v1::services::usage::v1::{
     CategorySeatUsage, CategoryUsage, DailySeatUsage, DailyUsage, GetUsageRequest,
     GetUsageResponse,
@@ -138,5 +139,36 @@ fn roundtrip_retention_without_downsampled_representation() {
             standard_days: 90,
             downsampled_days: None,
         }),
+    });
+}
+
+#[test]
+fn roundtrip_package_config_with_retention_defaults() {
+    assert_roundtrip(&PackageConfig {
+        uid: "business".into(),
+        retention_defaults: vec![
+            DataCategoryRetention {
+                category: DataCategory::Span as i32,
+                settings: Some(RetentionSettings {
+                    standard_days: 30,
+                    downsampled_days: Some(396),
+                }),
+            },
+            DataCategoryRetention {
+                category: DataCategory::Transaction as i32,
+                settings: Some(RetentionSettings {
+                    standard_days: 30,
+                    downsampled_days: Some(0),
+                }),
+            },
+            DataCategoryRetention {
+                category: DataCategory::Error as i32,
+                settings: Some(RetentionSettings {
+                    standard_days: 90,
+                    downsampled_days: None,
+                }),
+            },
+        ],
+        ..Default::default()
     });
 }


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/REVENG-330/introduce-retention-proto-support-for-package-plan-item-defaults

This adds the common retention protos (introduced in https://github.com/getsentry/sentry-protos/pull/368) to the pricing package proto.

This maps to the follwoing `TieredPlanItem.retention` and `TieredPlanItem.downsampled_event_retention` in the legacy billing system:
https://github.com/getsentry/getsentry/blob/b9f4cddb1d463c5f56083cad5b1201f165f52ccd/getsentry/billing/plans/tiered_plan_item.py#L38-L39