### PR TITLE
feat(billing): Add contract-owned retention override config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.57.1"
+version = "0.57.2"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/common/v1/retention.proto
+++ b/proto/sentry_protos/billing/v1/common/v1/retention.proto
@@ -16,9 +16,10 @@ message RetentionSettings {
 
   // The number of calendar days to retain downsampled data.
   //
-  // If this field is absent, the category has no separate downsampled data. If
-  // the value is zero, the resolver uses the effective standard retention. This
-  // value preserves legacy behavior. A positive value is a concrete duration.
+  // If this field is absent, the category has no separate downsampled data. A
+  // positive value is a concrete duration. A value of zero marks a downsampled
+  // representation that follows the standard retention; the consuming service
+  // decides how to apply it. This zero mirrors the legacy plan-item value.
   optional uint32 downsampled_days = 2;
 }
 

--- a/proto/sentry_protos/billing/v1/services/contract/v1/contract.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/contract.proto
@@ -5,9 +5,11 @@ package sentry_protos.billing.v1.services.contract.v1;
 import "sentry_protos/billing/v1/services/contract/v1/billing_config.proto";
 import "sentry_protos/billing/v1/services/contract/v1/contract_metadata.proto";
 import "sentry_protos/billing/v1/services/contract/v1/pricing_config.proto";
+import "sentry_protos/billing/v1/services/contract/v1/retention_config.proto";
 
 message Contract {
   ContractMetadata metadata = 1;
   BillingConfig billing_config = 2;
   PricingConfig pricing_config = 3;
+  RetentionConfig retention_config = 4;
 }

--- a/proto/sentry_protos/billing/v1/services/contract/v1/retention_config.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/retention_config.proto
@@ -1,0 +1,42 @@
+syntax = "proto3";
+
+package sentry_protos.billing.v1.services.contract.v1;
+
+import "sentry_protos/billing/v1/data_category.proto";
+
+// A single customer's sparse departure from the package retention defaults for
+// one billing data category.
+message RetentionOverride {
+  // The billing data category this override applies to. Package defaults and
+  // contract overrides use the same billing category identity.
+  sentry_protos.billing.v1.DataCategory category = 1;
+
+  // Standard/full-fidelity retention in calendar days. Absence means no
+  // standard override; a present value must be positive.
+  optional uint32 standard_days = 2;
+
+  // Downsampled retention in calendar days. Absence means no downsampled
+  // override; a present value must be positive. Unlike complete package
+  // settings, zero is invalid for a contract override.
+  optional uint32 downsampled_days = 3;
+}
+
+// The contract-owned retention overrides layered on top of package defaults.
+//
+// This is raw sparse input to effective-retention resolution, not the resolved
+// policy itself. Fields left unspecified fall through along their corresponding
+// package retention chain.
+message RetentionConfig {
+  // Opaque identifier of the retention policy revision this config projects.
+  // Consumers must treat it as opaque and must not parse it.
+  string revision = 1;
+
+  // Temporary legacy-compatible organization-wide retention in calendar days.
+  // Absence means the organization-wide layer does not apply; a present value
+  // must be positive. It applies to standard and to each downsampled
+  // representation already declared by the package.
+  optional uint32 organization_days = 2;
+
+  // Per-category sparse overrides. At most one entry per category.
+  repeated RetentionOverride overrides = 3;
+}

--- a/proto/sentry_protos/billing/v1/services/contract/v1/retention_config.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/retention_config.proto
@@ -4,39 +4,42 @@ package sentry_protos.billing.v1.services.contract.v1;
 
 import "sentry_protos/billing/v1/data_category.proto";
 
-// A single customer's sparse departure from the package retention defaults for
-// one billing data category.
+// A sparse override of the package retention defaults for one customer and one
+// billing data category.
 message RetentionOverride {
   // The billing data category this override applies to. Package defaults and
   // contract overrides use the same billing category identity.
   sentry_protos.billing.v1.DataCategory category = 1;
 
-  // Standard/full-fidelity retention in calendar days. Absence means no
-  // standard override; a present value must be positive.
+  // The standard retention in calendar days. This is the full-fidelity
+  // retention. If this field is absent, there is no standard override. A present
+  // value must be positive.
   optional uint32 standard_days = 2;
 
-  // Downsampled retention in calendar days. Absence means no downsampled
-  // override; a present value must be positive. Unlike complete package
-  // settings, zero is invalid for a contract override.
+  // The downsampled retention in calendar days. If this field is absent, there
+  // is no downsampled override. A present value must be positive. A complete
+  // package setting can use zero, but a contract override cannot.
   optional uint32 downsampled_days = 3;
 }
 
-// The contract-owned retention overrides layered on top of package defaults.
+// The contract-owned retention overrides. A service layers these overrides on
+// top of the package defaults.
 //
-// This is raw sparse input to effective-retention resolution, not the resolved
-// policy itself. Fields left unspecified fall through along their corresponding
+// This message is raw sparse input to effective-retention resolution. It is not
+// the resolved policy. If a field is absent, that field falls through to its
 // package retention chain.
 message RetentionConfig {
-  // Opaque identifier of the retention policy revision this config projects.
-  // Consumers must treat it as opaque and must not parse it.
+  // The identifier of the retention policy revision this config projects. This
+  // identifier is opaque. Do not parse it.
   string revision = 1;
 
-  // Temporary legacy-compatible organization-wide retention in calendar days.
-  // Absence means the organization-wide layer does not apply; a present value
-  // must be positive. It applies to standard and to each downsampled
-  // representation already declared by the package.
+  // The organization-wide retention in calendar days. This field is a temporary
+  // legacy-compatible value. If this field is absent, the organization-wide
+  // layer does not apply. A present value must be positive. This value applies
+  // to the standard retention and to each downsampled representation the package
+  // declares.
   optional uint32 organization_days = 2;
 
-  // Per-category sparse overrides. At most one entry per category.
+  // The per-category sparse overrides. Each category has one entry at most.
   repeated RetentionOverride overrides = 3;
 }

--- a/proto/sentry_protos/billing/v1/services/contract/v1/retention_config.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/retention_config.proto
@@ -29,10 +29,6 @@ message RetentionOverride {
 // the resolved policy. If a field is absent, that field falls through to its
 // package retention chain.
 message RetentionConfig {
-  // The identifier of the retention policy revision this config projects. This
-  // identifier is opaque. Do not parse it.
-  string revision = 1;
-
   // The organization-wide retention in calendar days. This field is a temporary
   // legacy-compatible value. If this field is absent, the organization-wide
   // layer does not apply. A present value must be positive. This value applies

--- a/proto/sentry_protos/billing/v1/services/contract/v1/retention_config.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/retention_config.proto
@@ -34,8 +34,8 @@ message RetentionConfig {
   // layer does not apply. A present value must be positive. This value applies
   // to the standard retention and to each downsampled representation the package
   // declares.
-  optional uint32 organization_days = 2;
+  optional uint32 organization_days = 1;
 
   // The per-category sparse overrides. Each category has one entry at most.
-  repeated RetentionOverride overrides = 3;
+  repeated RetentionOverride overrides = 2;
 }

--- a/py/tests/test_billing_v1.py
+++ b/py/tests/test_billing_v1.py
@@ -55,6 +55,10 @@ from sentry_protos.billing.v1.common.v1.retention_pb2 import (
     DataCategoryRetention,
     RetentionSettings,
 )
+from sentry_protos.billing.v1.services.contract.v1.retention_config_pb2 import (
+    RetentionConfig,
+    RetentionOverride,
+)
 from sentry_protos.billing.v1.services.package.v1.package_pb2 import PackageConfig
 from sentry_protos.billing.v1.services.package.v1.endpoint_get_package_pb2 import (
     GetPackageRequest,
@@ -453,6 +457,87 @@ def test_package_config_with_retention_defaults():
 
     assert parsed == package
     assert len(parsed.retention_defaults) == 3
+
+
+def test_contract_retention_config_sparse_overrides():
+    contract = Contract(
+        retention_config=RetentionConfig(
+            revision="rev_abc123",
+            # Organization-wide scalar applies to every category, above the
+            # per-category overrides.
+            organization_days=180,
+            overrides=[
+                # Standard-only override: downsampled uses the package default.
+                RetentionOverride(
+                    category=DataCategory.DATA_CATEGORY_SPAN,
+                    standard_days=90,
+                ),
+                # Downsampled-only override: standard uses the package default.
+                RetentionOverride(
+                    category=DataCategory.DATA_CATEGORY_TRANSACTION,
+                    downsampled_days=396,
+                ),
+                # Both sparse values may be set explicitly.
+                RetentionOverride(
+                    category=DataCategory.DATA_CATEGORY_ERROR,
+                    standard_days=90,
+                    downsampled_days=90,
+                ),
+            ],
+        ),
+    )
+
+    config = contract.retention_config
+    assert config.revision == "rev_abc123"
+    assert config.HasField("organization_days")
+    assert config.organization_days == 180
+    assert len(config.overrides) == 3
+
+    span_override = config.overrides[0]
+    assert span_override.category == DataCategory.DATA_CATEGORY_SPAN
+    assert span_override.HasField("standard_days")
+    assert span_override.standard_days == 90
+    assert not span_override.HasField("downsampled_days")
+
+    transaction_override = config.overrides[1]
+    assert transaction_override.category == DataCategory.DATA_CATEGORY_TRANSACTION
+    assert not transaction_override.HasField("standard_days")
+    assert transaction_override.HasField("downsampled_days")
+    assert transaction_override.downsampled_days == 396
+
+    error_override = config.overrides[2]
+    assert error_override.category == DataCategory.DATA_CATEGORY_ERROR
+    assert error_override.standard_days == 90
+    assert error_override.downsampled_days == 90
+
+    parsed = Contract()
+    parsed.ParseFromString(contract.SerializeToString())
+
+    assert parsed == contract
+    assert len(parsed.retention_config.overrides) == 3
+
+
+def test_contract_retention_config_absent_organization():
+    # An override set with no organization-wide scalar must be distinguishable
+    # from one that sets it, so resolution knows whether the org layer applies.
+    contract = Contract(
+        retention_config=RetentionConfig(
+            revision="rev_no_org",
+            overrides=[
+                RetentionOverride(
+                    category=DataCategory.DATA_CATEGORY_ERROR,
+                    standard_days=30,
+                ),
+            ],
+        ),
+    )
+
+    assert not contract.retention_config.HasField("organization_days")
+
+    parsed = Contract()
+    parsed.ParseFromString(contract.SerializeToString())
+    assert parsed == contract
+    assert not parsed.retention_config.HasField("organization_days")
 
 
 def test_get_package_request():

--- a/py/tests/test_billing_v1.py
+++ b/py/tests/test_billing_v1.py
@@ -462,7 +462,6 @@ def test_package_config_with_retention_defaults():
 def test_contract_retention_config_sparse_overrides():
     contract = Contract(
         retention_config=RetentionConfig(
-            revision="rev_abc123",
             # Organization-wide scalar applies to every category, above the
             # per-category overrides.
             organization_days=180,
@@ -488,7 +487,6 @@ def test_contract_retention_config_sparse_overrides():
     )
 
     config = contract.retention_config
-    assert config.revision == "rev_abc123"
     assert config.HasField("organization_days")
     assert config.organization_days == 180
     assert len(config.overrides) == 3
@@ -522,7 +520,6 @@ def test_contract_retention_config_absent_organization():
     # from one that sets it, so resolution knows whether the org layer applies.
     contract = Contract(
         retention_config=RetentionConfig(
-            revision="rev_no_org",
             overrides=[
                 RetentionOverride(
                     category=DataCategory.DATA_CATEGORY_ERROR,

--- a/rust/src/sentry_protos.billing.v1.common.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.common.v1.rs
@@ -467,9 +467,10 @@ pub struct RetentionSettings {
     pub standard_days: u32,
     /// The number of calendar days to retain downsampled data.
     ///
-    /// If this field is absent, the category has no separate downsampled data. If
-    /// the value is zero, the resolver uses the effective standard retention. This
-    /// value preserves legacy behavior. A positive value is a concrete duration.
+    /// If this field is absent, the category has no separate downsampled data. A
+    /// positive value is a concrete duration. A value of zero marks a downsampled
+    /// representation that follows the standard retention; the consuming service
+    /// decides how to apply it. This zero mirrors the legacy plan-item value.
     #[prost(uint32, optional, tag = "2")]
     pub downsampled_days: ::core::option::Option<u32>,
 }

--- a/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
@@ -598,6 +598,45 @@ pub struct ContractMetadata {
     #[prost(message, optional, tag = "5")]
     pub features: ::core::option::Option<FeatureOptions>,
 }
+/// A single customer's sparse departure from the package retention defaults for
+/// one billing data category.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct RetentionOverride {
+    /// The billing data category this override applies to. Package defaults and
+    /// contract overrides use the same billing category identity.
+    #[prost(enumeration = "super::super::super::DataCategory", tag = "1")]
+    pub category: i32,
+    /// Standard/full-fidelity retention in calendar days. Absence means no
+    /// standard override; a present value must be positive.
+    #[prost(uint32, optional, tag = "2")]
+    pub standard_days: ::core::option::Option<u32>,
+    /// Downsampled retention in calendar days. Absence means no downsampled
+    /// override; a present value must be positive. Unlike complete package
+    /// settings, zero is invalid for a contract override.
+    #[prost(uint32, optional, tag = "3")]
+    pub downsampled_days: ::core::option::Option<u32>,
+}
+/// The contract-owned retention overrides layered on top of package defaults.
+///
+/// This is raw sparse input to effective-retention resolution, not the resolved
+/// policy itself. Fields left unspecified fall through along their corresponding
+/// package retention chain.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RetentionConfig {
+    /// Opaque identifier of the retention policy revision this config projects.
+    /// Consumers must treat it as opaque and must not parse it.
+    #[prost(string, tag = "1")]
+    pub revision: ::prost::alloc::string::String,
+    /// Temporary legacy-compatible organization-wide retention in calendar days.
+    /// Absence means the organization-wide layer does not apply; a present value
+    /// must be positive. It applies to standard and to each downsampled
+    /// representation already declared by the package.
+    #[prost(uint32, optional, tag = "2")]
+    pub organization_days: ::core::option::Option<u32>,
+    /// Per-category sparse overrides. At most one entry per category.
+    #[prost(message, repeated, tag = "3")]
+    pub overrides: ::prost::alloc::vec::Vec<RetentionOverride>,
+}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Contract {
     #[prost(message, optional, tag = "1")]
@@ -606,6 +645,8 @@ pub struct Contract {
     pub billing_config: ::core::option::Option<BillingConfig>,
     #[prost(message, optional, tag = "3")]
     pub pricing_config: ::core::option::Option<PricingConfig>,
+    #[prost(message, optional, tag = "4")]
+    pub retention_config: ::core::option::Option<RetentionConfig>,
 }
 /// Applies a single user config to a contract immediately, repointing the
 /// contract's live parameters. Used internally by add_user_configs (there is no

--- a/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
@@ -630,10 +630,10 @@ pub struct RetentionConfig {
     /// layer does not apply. A present value must be positive. This value applies
     /// to the standard retention and to each downsampled representation the package
     /// declares.
-    #[prost(uint32, optional, tag = "2")]
+    #[prost(uint32, optional, tag = "1")]
     pub organization_days: ::core::option::Option<u32>,
     /// The per-category sparse overrides. Each category has one entry at most.
-    #[prost(message, repeated, tag = "3")]
+    #[prost(message, repeated, tag = "2")]
     pub overrides: ::prost::alloc::vec::Vec<RetentionOverride>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
@@ -625,10 +625,6 @@ pub struct RetentionOverride {
 /// package retention chain.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RetentionConfig {
-    /// The identifier of the retention policy revision this config projects. This
-    /// identifier is opaque. Do not parse it.
-    #[prost(string, tag = "1")]
-    pub revision: ::prost::alloc::string::String,
     /// The organization-wide retention in calendar days. This field is a temporary
     /// legacy-compatible value. If this field is absent, the organization-wide
     /// layer does not apply. A present value must be positive. This value applies

--- a/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
@@ -598,42 +598,45 @@ pub struct ContractMetadata {
     #[prost(message, optional, tag = "5")]
     pub features: ::core::option::Option<FeatureOptions>,
 }
-/// A single customer's sparse departure from the package retention defaults for
-/// one billing data category.
+/// A sparse override of the package retention defaults for one customer and one
+/// billing data category.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct RetentionOverride {
     /// The billing data category this override applies to. Package defaults and
     /// contract overrides use the same billing category identity.
     #[prost(enumeration = "super::super::super::DataCategory", tag = "1")]
     pub category: i32,
-    /// Standard/full-fidelity retention in calendar days. Absence means no
-    /// standard override; a present value must be positive.
+    /// The standard retention in calendar days. This is the full-fidelity
+    /// retention. If this field is absent, there is no standard override. A present
+    /// value must be positive.
     #[prost(uint32, optional, tag = "2")]
     pub standard_days: ::core::option::Option<u32>,
-    /// Downsampled retention in calendar days. Absence means no downsampled
-    /// override; a present value must be positive. Unlike complete package
-    /// settings, zero is invalid for a contract override.
+    /// The downsampled retention in calendar days. If this field is absent, there
+    /// is no downsampled override. A present value must be positive. A complete
+    /// package setting can use zero, but a contract override cannot.
     #[prost(uint32, optional, tag = "3")]
     pub downsampled_days: ::core::option::Option<u32>,
 }
-/// The contract-owned retention overrides layered on top of package defaults.
+/// The contract-owned retention overrides. A service layers these overrides on
+/// top of the package defaults.
 ///
-/// This is raw sparse input to effective-retention resolution, not the resolved
-/// policy itself. Fields left unspecified fall through along their corresponding
+/// This message is raw sparse input to effective-retention resolution. It is not
+/// the resolved policy. If a field is absent, that field falls through to its
 /// package retention chain.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RetentionConfig {
-    /// Opaque identifier of the retention policy revision this config projects.
-    /// Consumers must treat it as opaque and must not parse it.
+    /// The identifier of the retention policy revision this config projects. This
+    /// identifier is opaque. Do not parse it.
     #[prost(string, tag = "1")]
     pub revision: ::prost::alloc::string::String,
-    /// Temporary legacy-compatible organization-wide retention in calendar days.
-    /// Absence means the organization-wide layer does not apply; a present value
-    /// must be positive. It applies to standard and to each downsampled
-    /// representation already declared by the package.
+    /// The organization-wide retention in calendar days. This field is a temporary
+    /// legacy-compatible value. If this field is absent, the organization-wide
+    /// layer does not apply. A present value must be positive. This value applies
+    /// to the standard retention and to each downsampled representation the package
+    /// declares.
     #[prost(uint32, optional, tag = "2")]
     pub organization_days: ::core::option::Option<u32>,
-    /// Per-category sparse overrides. At most one entry per category.
+    /// The per-category sparse overrides. Each category has one entry at most.
     #[prost(message, repeated, tag = "3")]
     pub overrides: ::prost::alloc::vec::Vec<RetentionOverride>,
 }

--- a/rust/tests/codegen_test.rs
+++ b/rust/tests/codegen_test.rs
@@ -17,7 +17,9 @@ use sentry_protos::billing::v1::DataCategory;
 use sentry_protos::billing::v1::Date;
 use sentry_protos::billing::v1::SeatCategory;
 use sentry_protos::billing::v1::UsageData;
-use sentry_protos::billing::v1::services::contract::v1::{Contract, GetContractRequest};
+use sentry_protos::billing::v1::services::contract::v1::{
+    Contract, GetContractRequest, RetentionConfig, RetentionOverride,
+};
 use sentry_protos::billing::v1::services::package::v1::PackageConfig;
 use sentry_protos::billing::v1::services::usage::v1::{
     CategorySeatUsage, CategoryUsage, DailySeatUsage, DailyUsage, GetUsageRequest,
@@ -169,6 +171,31 @@ fn roundtrip_package_config_with_retention_defaults() {
                 }),
             },
         ],
+        ..Default::default()
+    });
+}
+
+#[test]
+fn roundtrip_contract_retention_config() {
+    assert_roundtrip(&Contract {
+        retention_config: Some(RetentionConfig {
+            revision: "rev_abc123".into(),
+            organization_days: Some(180),
+            overrides: vec![
+                // Standard-only override: downsampled uses the package default.
+                RetentionOverride {
+                    category: DataCategory::Span as i32,
+                    standard_days: Some(90),
+                    downsampled_days: None,
+                },
+                // Downsampled-only override: standard uses the package default.
+                RetentionOverride {
+                    category: DataCategory::Transaction as i32,
+                    standard_days: None,
+                    downsampled_days: Some(396),
+                },
+            ],
+        }),
         ..Default::default()
     });
 }

--- a/rust/tests/codegen_test.rs
+++ b/rust/tests/codegen_test.rs
@@ -179,7 +179,6 @@ fn roundtrip_package_config_with_retention_defaults() {
 fn roundtrip_contract_retention_config() {
     assert_roundtrip(&Contract {
         retention_config: Some(RetentionConfig {
-            revision: "rev_abc123".into(),
             organization_days: Some(180),
             overrides: vec![
                 // Standard-only override: downsampled uses the package default.


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/REVENG-331/introduce-retention-proto-support-for-contracts-customers-subscription

This PR adds retention overrides (that are specific to the customer) at the contract level. 

There are two retention override levels at the customer level:
- category specific retention overrides (e.g. spans)
- and organization wide retention override.

The analogue for this in the legacy billing system is:
-  `BillingMetricHistory.retention_days` and `BillingMetricHistory.retention_days_downsampled` https://github.com/getsentry/getsentry/blob/b9f4cddb1d463c5f56083cad5b1201f165f52ccd/getsentry/models/billingmetrichistory.py#L491-L493
- `Subscription.retention_days` https://github.com/getsentry/getsentry/blob/60d70fe37a7d8431842357aba588e274925fb430/getsentry/models/subscription.py#L256


