### PR TITLE
feat(snuba): add LIMIT BY support to TraceItemTableRequest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
@@ -44,9 +44,9 @@ message TraceItemTableRequest {
   // `order_by`). E.g. grouping by project and ordering by count, `limit` = 100
   // returns the top 100 rows for every project.
   message LimitBy {
-    // The columns that define a group; rows sharing the same values for all of
-    // them count against the same per-group limit.
-    repeated Column columns = 1;
+    // Aliases (labels) of the selected columns that define a group. Each alias
+    // must reference a selected column that also appears in `group_by`.
+    repeated string columns = 1;
     // Maximum number of rows to keep per group.
     uint32 limit = 2;
   }

--- a/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
@@ -63,7 +63,9 @@ message TraceItemTableRequest {
 
   repeated AttributeKey group_by = 5;
 
-  uint32 limit = 6 [deprecated = true];
+  // Global cap on the total number of returned rows. Cannot be set together
+  // with `limit_by`; specify one or the other, not both.
+  uint32 limit = 6;
 
   // optional, used for pagination, the next page token will be returned in the response
   PageToken page_token = 7;
@@ -79,7 +81,8 @@ message TraceItemTableRequest {
   // ex: Find spans in traces containing a span with op = 'db' that also contain errors with message = 'timeout'
   repeated TraceItemFilterWithType trace_filters = 10;
 
-  // optional, limits the number of returned rows per group. See LimitBy.
+  // optional, limits the number of returned rows per group. Cannot be set
+  // together with `limit`; specify one or the other, not both. See LimitBy.
   LimitBy limit_by = 11;
 }
 

--- a/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
@@ -44,9 +44,10 @@ message TraceItemTableRequest {
   // `order_by`). E.g. grouping by project and ordering by count, `limit` = 100
   // returns the top 100 rows for every project.
   message LimitBy {
-    // Aliases (labels) of the selected columns that define a group. Each alias
-    // must reference a selected column that also appears in `group_by`.
-    repeated string columns = 1;
+    // The columns that define a group. Each may be a column, an alias of a
+    // selected column (a Column with only `label` set), or a non-aggregate
+    // transformation (e.g. a formula). Aggregations are not allowed.
+    repeated Column columns = 1;
     // Maximum number of rows to keep per group.
     uint32 limit = 2;
   }

--- a/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
@@ -39,23 +39,10 @@ message TraceItemTableRequest {
     Sort sort = 3;
   }
 
-  // Restricts how many rows are returned per distinct combination of the given
-  // columns, equivalent to ClickHouse's `LIMIT n BY expr, ...` clause
-  // (https://clickhouse.com/docs/sql-reference/statements/select/limit-by).
-  // LIMIT BY is applied together with ORDER BY, so within each group defined by
-  // `columns` the top `limit` rows (as sorted by `order_by`) are kept. The
-  // top-level `limit` field still caps the total number of rows returned.
-  //
-  // Example: selecting (project_id, transaction, count()) ordered by count()
-  // descending with a LimitBy of {columns: [project_id], limit: 100} returns
-  // the top 100 transactions for every project in a single query, instead of
-  // issuing one query per project.
+  // ClickHouse `LIMIT n BY expr, ...`: keep the top `limit` rows per distinct
+  // combination of `columns`.
   message LimitBy {
-    // The columns whose distinct value combinations define each group. Every
-    // column referenced here must also be selected in `columns`.
     repeated Column columns = 1;
-
-    // The maximum number of rows to keep per group. Must be greater than 0.
     uint32 limit = 2;
   }
 
@@ -71,7 +58,7 @@ message TraceItemTableRequest {
 
   repeated AttributeKey group_by = 5;
 
-  uint32 limit = 6;
+  uint32 limit = 6 [deprecated = true];
 
   // optional, used for pagination, the next page token will be returned in the response
   PageToken page_token = 7;
@@ -87,8 +74,7 @@ message TraceItemTableRequest {
   // ex: Find spans in traces containing a span with op = 'db' that also contain errors with message = 'timeout'
   repeated TraceItemFilterWithType trace_filters = 10;
 
-  // optional, restricts the number of returned rows per distinct combination of
-  // the LimitBy columns (ClickHouse `LIMIT n BY ...`). See LimitBy for details.
+  // optional, ClickHouse `LIMIT n BY ...`. See LimitBy.
   LimitBy limit_by = 11;
 }
 

--- a/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
@@ -44,10 +44,18 @@ message TraceItemTableRequest {
   // `order_by`). E.g. grouping by project and ordering by count, `limit` = 100
   // returns the top 100 rows for every project.
   message LimitBy {
-    // The columns that define a group. Each may be a column, an alias of a
-    // selected column (a Column with only `label` set), or a non-aggregate
-    // transformation (e.g. a formula). Aggregations are not allowed.
-    repeated Column columns = 1;
+    // A single grouping key. It is either a column (referenced by attribute key)
+    // or the label of a selected column. To group by a transformation, select it
+    // as a column and reference it here by its label. This intentionally cannot
+    // express an aggregation, which ClickHouse cannot LIMIT BY.
+    message LimitByColumn {
+      oneof column {
+        AttributeKey key = 1;
+        string label = 2;
+      }
+    }
+    // The keys that define a group.
+    repeated LimitByColumn columns = 1;
     // Maximum number of rows to keep per group.
     uint32 limit = 2;
   }

--- a/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
@@ -39,10 +39,15 @@ message TraceItemTableRequest {
     Sort sort = 3;
   }
 
-  // ClickHouse `LIMIT n BY expr, ...`: keep the top `limit` rows per distinct
-  // combination of `columns`.
+  // Limits results per group rather than globally: for each distinct
+  // combination of `columns`, keep at most `limit` rows (the first `limit` per
+  // `order_by`). E.g. grouping by project and ordering by count, `limit` = 100
+  // returns the top 100 rows for every project.
   message LimitBy {
+    // The columns that define a group; rows sharing the same values for all of
+    // them count against the same per-group limit.
     repeated Column columns = 1;
+    // Maximum number of rows to keep per group.
     uint32 limit = 2;
   }
 
@@ -74,7 +79,7 @@ message TraceItemTableRequest {
   // ex: Find spans in traces containing a span with op = 'db' that also contain errors with message = 'timeout'
   repeated TraceItemFilterWithType trace_filters = 10;
 
-  // optional, ClickHouse `LIMIT n BY ...`. See LimitBy.
+  // optional, limits the number of returned rows per group. See LimitBy.
   LimitBy limit_by = 11;
 }
 

--- a/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
@@ -39,6 +39,26 @@ message TraceItemTableRequest {
     Sort sort = 3;
   }
 
+  // Restricts how many rows are returned per distinct combination of the given
+  // columns, equivalent to ClickHouse's `LIMIT n BY expr, ...` clause
+  // (https://clickhouse.com/docs/sql-reference/statements/select/limit-by).
+  // LIMIT BY is applied together with ORDER BY, so within each group defined by
+  // `columns` the top `limit` rows (as sorted by `order_by`) are kept. The
+  // top-level `limit` field still caps the total number of rows returned.
+  //
+  // Example: selecting (project_id, transaction, count()) ordered by count()
+  // descending with a LimitBy of {columns: [project_id], limit: 100} returns
+  // the top 100 transactions for every project in a single query, instead of
+  // issuing one query per project.
+  message LimitBy {
+    // The columns whose distinct value combinations define each group. Every
+    // column referenced here must also be selected in `columns`.
+    repeated Column columns = 1;
+
+    // The maximum number of rows to keep per group. Must be greater than 0.
+    uint32 limit = 2;
+  }
+
   RequestMeta meta = 1;
 
   // the columns or aggregations you want to get
@@ -66,6 +86,10 @@ message TraceItemTableRequest {
   // If specified, the endpoint will only consider traces that match all the filters.
   // ex: Find spans in traces containing a span with op = 'db' that also contain errors with message = 'timeout'
   repeated TraceItemFilterWithType trace_filters = 10;
+
+  // optional, restricts the number of returned rows per distinct combination of
+  // the LimitBy columns (ClickHouse `LIMIT n BY ...`). See LimitBy for details.
+  LimitBy limit_by = 11;
 }
 
 message AggregationAndFilter {

--- a/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
@@ -48,14 +48,14 @@ message TraceItemTableRequest {
     // or the label of a selected column. To group by a transformation, select it
     // as a column and reference it here by its label. This intentionally cannot
     // express an aggregation, which ClickHouse cannot LIMIT BY.
-    message LimitByColumn {
+    message Column {
       oneof column {
         AttributeKey key = 1;
         string label = 2;
       }
     }
     // The keys that define a group.
-    repeated LimitByColumn columns = 1;
+    repeated Column columns = 1;
     // Maximum number of rows to keep per group.
     uint32 limit = 2;
   }

--- a/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
@@ -72,8 +72,9 @@ message TraceItemTableRequest {
 
   repeated AttributeKey group_by = 5;
 
-  // Global cap on the total number of returned rows. Cannot be set together
-  // with `limit_by`; specify one or the other, not both.
+  // Caps the total number of returned rows. May be combined with `limit_by`,
+  // where `limit_by` bounds the rows kept per group and this bounds the overall
+  // result (e.g. the number of groups shown).
   uint32 limit = 6;
 
   // optional, used for pagination, the next page token will be returned in the response
@@ -90,8 +91,8 @@ message TraceItemTableRequest {
   // ex: Find spans in traces containing a span with op = 'db' that also contain errors with message = 'timeout'
   repeated TraceItemFilterWithType trace_filters = 10;
 
-  // optional, limits the number of returned rows per group. Cannot be set
-  // together with `limit`; specify one or the other, not both. See LimitBy.
+  // optional, limits the number of returned rows per group. May be combined
+  // with the top-level `limit`, which caps the overall result. See LimitBy.
   LimitBy limit_by = 11;
 }
 

--- a/rust/src/sentry_protos.snuba.v1.rs
+++ b/rust/src/sentry_protos.snuba.v1.rs
@@ -2418,12 +2418,12 @@ pub mod trace_item_table_request {
     /// combination of `columns`, keep at most `limit` rows (the first `limit` per
     /// `order_by`). E.g. grouping by project and ordering by count, `limit` = 100
     /// returns the top 100 rows for every project.
-    #[derive(Clone, PartialEq, ::prost::Message)]
+    #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
     pub struct LimitBy {
-        /// The columns that define a group; rows sharing the same values for all of
-        /// them count against the same per-group limit.
-        #[prost(message, repeated, tag = "1")]
-        pub columns: ::prost::alloc::vec::Vec<super::Column>,
+        /// Aliases (labels) of the selected columns that define a group. Each alias
+        /// must reference a selected column that also appears in `group_by`.
+        #[prost(string, repeated, tag = "1")]
+        pub columns: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
         /// Maximum number of rows to keep per group.
         #[prost(uint32, tag = "2")]
         pub limit: u32,

--- a/rust/src/sentry_protos.snuba.v1.rs
+++ b/rust/src/sentry_protos.snuba.v1.rs
@@ -2343,7 +2343,7 @@ pub struct TraceItemTableRequest {
     /// ex: Find spans in traces containing a span with op = 'db' that also contain errors with message = 'timeout'
     #[prost(message, repeated, tag = "10")]
     pub trace_filters: ::prost::alloc::vec::Vec<TraceItemFilterWithType>,
-    /// optional, ClickHouse `LIMIT n BY ...`. See LimitBy.
+    /// optional, limits the number of returned rows per group. See LimitBy.
     #[prost(message, optional, tag = "11")]
     pub limit_by: ::core::option::Option<trace_item_table_request::LimitBy>,
 }
@@ -2412,12 +2412,17 @@ pub mod trace_item_table_request {
             }
         }
     }
-    /// ClickHouse `LIMIT n BY expr, ...`: keep the top `limit` rows per distinct
-    /// combination of `columns`.
+    /// Limits results per group rather than globally: for each distinct
+    /// combination of `columns`, keep at most `limit` rows (the first `limit` per
+    /// `order_by`). E.g. grouping by project and ordering by count, `limit` = 100
+    /// returns the top 100 rows for every project.
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct LimitBy {
+        /// The columns that define a group; rows sharing the same values for all of
+        /// them count against the same per-group limit.
         #[prost(message, repeated, tag = "1")]
         pub columns: ::prost::alloc::vec::Vec<super::Column>,
+        /// Maximum number of rows to keep per group.
         #[prost(uint32, tag = "2")]
         pub limit: u32,
     }

--- a/rust/src/sentry_protos.snuba.v1.rs
+++ b/rust/src/sentry_protos.snuba.v1.rs
@@ -2326,8 +2326,9 @@ pub struct TraceItemTableRequest {
     pub order_by: ::prost::alloc::vec::Vec<trace_item_table_request::OrderBy>,
     #[prost(message, repeated, tag = "5")]
     pub group_by: ::prost::alloc::vec::Vec<AttributeKey>,
-    /// Global cap on the total number of returned rows. Cannot be set together
-    /// with `limit_by`; specify one or the other, not both.
+    /// Caps the total number of returned rows. May be combined with `limit_by`,
+    /// where `limit_by` bounds the rows kept per group and this bounds the overall
+    /// result (e.g. the number of groups shown).
     #[prost(uint32, tag = "6")]
     pub limit: u32,
     /// optional, used for pagination, the next page token will be returned in the response
@@ -2344,8 +2345,8 @@ pub struct TraceItemTableRequest {
     /// ex: Find spans in traces containing a span with op = 'db' that also contain errors with message = 'timeout'
     #[prost(message, repeated, tag = "10")]
     pub trace_filters: ::prost::alloc::vec::Vec<TraceItemFilterWithType>,
-    /// optional, limits the number of returned rows per group. Cannot be set
-    /// together with `limit`; specify one or the other, not both. See LimitBy.
+    /// optional, limits the number of returned rows per group. May be combined
+    /// with the top-level `limit`, which caps the overall result. See LimitBy.
     #[prost(message, optional, tag = "11")]
     pub limit_by: ::core::option::Option<trace_item_table_request::LimitBy>,
 }
@@ -2422,7 +2423,7 @@ pub mod trace_item_table_request {
     pub struct LimitBy {
         /// The keys that define a group.
         #[prost(message, repeated, tag = "1")]
-        pub columns: ::prost::alloc::vec::Vec<limit_by::LimitByColumn>,
+        pub columns: ::prost::alloc::vec::Vec<limit_by::Column>,
         /// Maximum number of rows to keep per group.
         #[prost(uint32, tag = "2")]
         pub limit: u32,
@@ -2434,12 +2435,12 @@ pub mod trace_item_table_request {
         /// as a column and reference it here by its label. This intentionally cannot
         /// express an aggregation, which ClickHouse cannot LIMIT BY.
         #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-        pub struct LimitByColumn {
-            #[prost(oneof = "limit_by_column::Column", tags = "1, 2")]
-            pub column: ::core::option::Option<limit_by_column::Column>,
+        pub struct Column {
+            #[prost(oneof = "column::Column", tags = "1, 2")]
+            pub column: ::core::option::Option<column::Column>,
         }
-        /// Nested message and enum types in `LimitByColumn`.
-        pub mod limit_by_column {
+        /// Nested message and enum types in `Column`.
+        pub mod column {
             #[derive(Clone, PartialEq, Eq, Hash, ::prost::Oneof)]
             pub enum Column {
                 #[prost(message, tag = "1")]

--- a/rust/src/sentry_protos.snuba.v1.rs
+++ b/rust/src/sentry_protos.snuba.v1.rs
@@ -2326,6 +2326,7 @@ pub struct TraceItemTableRequest {
     pub order_by: ::prost::alloc::vec::Vec<trace_item_table_request::OrderBy>,
     #[prost(message, repeated, tag = "5")]
     pub group_by: ::prost::alloc::vec::Vec<AttributeKey>,
+    #[deprecated]
     #[prost(uint32, tag = "6")]
     pub limit: u32,
     /// optional, used for pagination, the next page token will be returned in the response
@@ -2342,8 +2343,7 @@ pub struct TraceItemTableRequest {
     /// ex: Find spans in traces containing a span with op = 'db' that also contain errors with message = 'timeout'
     #[prost(message, repeated, tag = "10")]
     pub trace_filters: ::prost::alloc::vec::Vec<TraceItemFilterWithType>,
-    /// optional, restricts the number of returned rows per distinct combination of
-    /// the LimitBy columns (ClickHouse `LIMIT n BY ...`). See LimitBy for details.
+    /// optional, ClickHouse `LIMIT n BY ...`. See LimitBy.
     #[prost(message, optional, tag = "11")]
     pub limit_by: ::core::option::Option<trace_item_table_request::LimitBy>,
 }
@@ -2412,24 +2412,12 @@ pub mod trace_item_table_request {
             }
         }
     }
-    /// Restricts how many rows are returned per distinct combination of the given
-    /// columns, equivalent to ClickHouse's `LIMIT n BY expr, ...` clause
-    /// (<https://clickhouse.com/docs/sql-reference/statements/select/limit-by>).
-    /// LIMIT BY is applied together with ORDER BY, so within each group defined by
-    /// `columns` the top `limit` rows (as sorted by `order_by`) are kept. The
-    /// top-level `limit` field still caps the total number of rows returned.
-    ///
-    /// Example: selecting (project_id, transaction, count()) ordered by count()
-    /// descending with a LimitBy of {columns: \[project_id\], limit: 100} returns
-    /// the top 100 transactions for every project in a single query, instead of
-    /// issuing one query per project.
+    /// ClickHouse `LIMIT n BY expr, ...`: keep the top `limit` rows per distinct
+    /// combination of `columns`.
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct LimitBy {
-        /// The columns whose distinct value combinations define each group. Every
-        /// column referenced here must also be selected in `columns`.
         #[prost(message, repeated, tag = "1")]
         pub columns: ::prost::alloc::vec::Vec<super::Column>,
-        /// The maximum number of rows to keep per group. Must be greater than 0.
         #[prost(uint32, tag = "2")]
         pub limit: u32,
     }

--- a/rust/src/sentry_protos.snuba.v1.rs
+++ b/rust/src/sentry_protos.snuba.v1.rs
@@ -2326,7 +2326,8 @@ pub struct TraceItemTableRequest {
     pub order_by: ::prost::alloc::vec::Vec<trace_item_table_request::OrderBy>,
     #[prost(message, repeated, tag = "5")]
     pub group_by: ::prost::alloc::vec::Vec<AttributeKey>,
-    #[deprecated]
+    /// Global cap on the total number of returned rows. Cannot be set together
+    /// with `limit_by`; specify one or the other, not both.
     #[prost(uint32, tag = "6")]
     pub limit: u32,
     /// optional, used for pagination, the next page token will be returned in the response
@@ -2343,7 +2344,8 @@ pub struct TraceItemTableRequest {
     /// ex: Find spans in traces containing a span with op = 'db' that also contain errors with message = 'timeout'
     #[prost(message, repeated, tag = "10")]
     pub trace_filters: ::prost::alloc::vec::Vec<TraceItemFilterWithType>,
-    /// optional, limits the number of returned rows per group. See LimitBy.
+    /// optional, limits the number of returned rows per group. Cannot be set
+    /// together with `limit`; specify one or the other, not both. See LimitBy.
     #[prost(message, optional, tag = "11")]
     pub limit_by: ::core::option::Option<trace_item_table_request::LimitBy>,
 }

--- a/rust/src/sentry_protos.snuba.v1.rs
+++ b/rust/src/sentry_protos.snuba.v1.rs
@@ -2342,6 +2342,10 @@ pub struct TraceItemTableRequest {
     /// ex: Find spans in traces containing a span with op = 'db' that also contain errors with message = 'timeout'
     #[prost(message, repeated, tag = "10")]
     pub trace_filters: ::prost::alloc::vec::Vec<TraceItemFilterWithType>,
+    /// optional, restricts the number of returned rows per distinct combination of
+    /// the LimitBy columns (ClickHouse `LIMIT n BY ...`). See LimitBy for details.
+    #[prost(message, optional, tag = "11")]
+    pub limit_by: ::core::option::Option<trace_item_table_request::LimitBy>,
 }
 /// Nested message and enum types in `TraceItemTableRequest`.
 pub mod trace_item_table_request {
@@ -2407,6 +2411,27 @@ pub mod trace_item_table_request {
                 }
             }
         }
+    }
+    /// Restricts how many rows are returned per distinct combination of the given
+    /// columns, equivalent to ClickHouse's `LIMIT n BY expr, ...` clause
+    /// (<https://clickhouse.com/docs/sql-reference/statements/select/limit-by>).
+    /// LIMIT BY is applied together with ORDER BY, so within each group defined by
+    /// `columns` the top `limit` rows (as sorted by `order_by`) are kept. The
+    /// top-level `limit` field still caps the total number of rows returned.
+    ///
+    /// Example: selecting (project_id, transaction, count()) ordered by count()
+    /// descending with a LimitBy of {columns: \[project_id\], limit: 100} returns
+    /// the top 100 transactions for every project in a single query, instead of
+    /// issuing one query per project.
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct LimitBy {
+        /// The columns whose distinct value combinations define each group. Every
+        /// column referenced here must also be selected in `columns`.
+        #[prost(message, repeated, tag = "1")]
+        pub columns: ::prost::alloc::vec::Vec<super::Column>,
+        /// The maximum number of rows to keep per group. Must be greater than 0.
+        #[prost(uint32, tag = "2")]
+        pub limit: u32,
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/rust/src/sentry_protos.snuba.v1.rs
+++ b/rust/src/sentry_protos.snuba.v1.rs
@@ -2418,12 +2418,13 @@ pub mod trace_item_table_request {
     /// combination of `columns`, keep at most `limit` rows (the first `limit` per
     /// `order_by`). E.g. grouping by project and ordering by count, `limit` = 100
     /// returns the top 100 rows for every project.
-    #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct LimitBy {
-        /// Aliases (labels) of the selected columns that define a group. Each alias
-        /// must reference a selected column that also appears in `group_by`.
-        #[prost(string, repeated, tag = "1")]
-        pub columns: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+        /// The columns that define a group. Each may be a column, an alias of a
+        /// selected column (a Column with only `label` set), or a non-aggregate
+        /// transformation (e.g. a formula). Aggregations are not allowed.
+        #[prost(message, repeated, tag = "1")]
+        pub columns: ::prost::alloc::vec::Vec<super::Column>,
         /// Maximum number of rows to keep per group.
         #[prost(uint32, tag = "2")]
         pub limit: u32,

--- a/rust/src/sentry_protos.snuba.v1.rs
+++ b/rust/src/sentry_protos.snuba.v1.rs
@@ -2420,14 +2420,34 @@ pub mod trace_item_table_request {
     /// returns the top 100 rows for every project.
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct LimitBy {
-        /// The columns that define a group. Each may be a column, an alias of a
-        /// selected column (a Column with only `label` set), or a non-aggregate
-        /// transformation (e.g. a formula). Aggregations are not allowed.
+        /// The keys that define a group.
         #[prost(message, repeated, tag = "1")]
-        pub columns: ::prost::alloc::vec::Vec<super::Column>,
+        pub columns: ::prost::alloc::vec::Vec<limit_by::LimitByColumn>,
         /// Maximum number of rows to keep per group.
         #[prost(uint32, tag = "2")]
         pub limit: u32,
+    }
+    /// Nested message and enum types in `LimitBy`.
+    pub mod limit_by {
+        /// A single grouping key. It is either a column (referenced by attribute key)
+        /// or the label of a selected column. To group by a transformation, select it
+        /// as a column and reference it here by its label. This intentionally cannot
+        /// express an aggregation, which ClickHouse cannot LIMIT BY.
+        #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+        pub struct LimitByColumn {
+            #[prost(oneof = "limit_by_column::Column", tags = "1, 2")]
+            pub column: ::core::option::Option<limit_by_column::Column>,
+        }
+        /// Nested message and enum types in `LimitByColumn`.
+        pub mod limit_by_column {
+            #[derive(Clone, PartialEq, Eq, Hash, ::prost::Oneof)]
+            pub enum Column {
+                #[prost(message, tag = "1")]
+                Key(super::super::super::AttributeKey),
+                #[prost(string, tag = "2")]
+                Label(::prost::alloc::string::String),
+            }
+        }
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]


### PR DESCRIPTION
## Summary

Adds a `LimitBy` message and `limit_by` field to `TraceItemTableRequest` so callers can request a ClickHouse [`LIMIT n BY ...`](https://clickhouse.com/docs/sql-reference/statements/select/limit-by) clause on TraceItemTable (EAP) queries.

This lets a caller fetch the top N rows per distinct combination of columns (e.g. the top N transactions for **every** project) in a single query, instead of issuing one query per group.

### Motivation

The new EAP-based per-org dynamic sampling system needs a `LIMIT BY` query (supported in generic metrics but not EAP). Running it per-project instead would mean ~150 qps across ~160k projects on top of the existing ~90 qps, vs. one query per org (~9k orgs). See [EAP-629](https://linear.app/getsentry/issue/EAP-629/investigate-limit-by-support-in-eap-queries).

### Change

```proto
message TraceItemTableRequest {
  message LimitBy {
    repeated Column columns = 1;  // group definition; each must be selected
    uint32 limit = 2;             // max rows per group, > 0
  }
  // ...
  LimitBy limit_by = 11;
}
```

Adding a new message and a new field (11) is backwards compatible.

The consuming Snuba implementation is in getsentry/snuba (branch `claude/sentry-protos-changes-rzv35z`) and depends on this being released.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016uFnidX85bgsSjSR9UkXZR

---
_Generated by [Claude Code](https://claude.ai/code/session_016uFnidX85bgsSjSR9UkXZR)_