### PR TITLE
feat(snuba): add SEMVER sort option to EAP OrderBy messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.45.1"
+version = "0.46.0"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/snuba/v1/endpoint_get_traces.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_get_traces.proto
@@ -73,6 +73,10 @@ message GetTracesRequest {
       // Natural ordering: embedded runs of digits are compared by their
       // numeric value, so e.g. "item2" sorts before "item10".
       SORT_NATURAL = 2;
+      // Semantic-version ordering: values are parsed as semantic versions
+      // (https://semver.org) and compared component by component, so e.g.
+      // "1.9.0" sorts before "1.10.0".
+      SORT_SEMVER = 3;
     }
 
     TraceAttribute.Key key = 1;

--- a/proto/sentry_protos/snuba/v1/endpoint_trace_item_attributes.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_trace_item_attributes.proto
@@ -44,6 +44,10 @@ message TraceItemAttributeNamesRequest {
       // Natural ordering: embedded runs of digits are compared by their
       // numeric value, so e.g. "item2" sorts before "item10".
       SORT_NATURAL = 2;
+      // Semantic-version ordering: values are parsed as semantic versions
+      // (https://semver.org) and compared component by component, so e.g.
+      // "1.9.0" sorts before "1.10.0".
+      SORT_SEMVER = 3;
     }
 
     // The column to order the returned attribute names by.
@@ -167,6 +171,10 @@ message TraceItemAttributeValuesRequest {
       // Natural ordering: embedded runs of digits are compared by their
       // numeric value, so e.g. "item2" sorts before "item10".
       SORT_NATURAL = 2;
+      // Semantic-version ordering: values are parsed as semantic versions
+      // (https://semver.org) and compared component by component, so e.g.
+      // "1.9.0" sorts before "1.10.0".
+      SORT_SEMVER = 3;
     }
 
     // The column to order the returned values by.

--- a/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto
@@ -27,6 +27,10 @@ message TraceItemTableRequest {
       // Natural ordering: embedded runs of digits are compared by their
       // numeric value, so e.g. "item2" sorts before "item10".
       SORT_NATURAL = 2;
+      // Semantic-version ordering: values are parsed as semantic versions
+      // (https://semver.org) and compared component by component, so e.g.
+      // "1.9.0" sorts before "1.10.0".
+      SORT_SEMVER = 3;
     }
 
     Column column = 1;

--- a/py/tests/test_snuba_v1.py
+++ b/py/tests/test_snuba_v1.py
@@ -917,6 +917,62 @@ def test_example_attribute_values_request_natural_sort() -> None:
     )
 
 
+def test_example_attribute_names_request_semver_sort() -> None:
+    # Opt in to semantic-version ordering of attribute names so that version-like
+    # names are sorted by semantic version (e.g. "1.9.0" before "1.10.0") rather
+    # than lexicographically. Leaving `sort` unset (or using SORT_DEFAULT)
+    # preserves the historical lexicographic ordering.
+    request = TraceItemAttributeNamesRequest(
+        meta=COMMON_META,
+        limit=100,
+        type=AttributeKey.Type.TYPE_STRING,
+        order_by=TraceItemAttributeNamesRequest.OrderBy(
+            column=TraceItemAttributeNamesRequest.OrderBy.COLUMN_NAME,
+            sort=TraceItemAttributeNamesRequest.OrderBy.SORT_SEMVER,
+        ),
+    )
+
+    assert (
+        request.order_by.sort
+        == TraceItemAttributeNamesRequest.OrderBy.SORT_SEMVER
+    )
+    # the field round-trips through serialization
+    roundtripped = TraceItemAttributeNamesRequest()
+    roundtripped.ParseFromString(request.SerializeToString())
+    assert (
+        roundtripped.order_by.sort
+        == TraceItemAttributeNamesRequest.OrderBy.SORT_SEMVER
+    )
+
+
+def test_example_attribute_values_request_semver_sort() -> None:
+    # Opt in to semantic-version ordering of attribute values so that version-like
+    # values are sorted by semantic version (e.g. "1.9.0" before "1.10.0") rather
+    # than lexicographically. Leaving `sort` unset (or using SORT_DEFAULT)
+    # preserves the historical lexicographic ordering.
+    request = TraceItemAttributeValuesRequest(
+        meta=COMMON_META,
+        key=AttributeKey(type=AttributeKey.TYPE_STRING, name="sentry.release"),
+        limit=100,
+        order_by=TraceItemAttributeValuesRequest.OrderBy(
+            column=TraceItemAttributeValuesRequest.OrderBy.COLUMN_VALUE,
+            sort=TraceItemAttributeValuesRequest.OrderBy.SORT_SEMVER,
+        ),
+    )
+
+    assert (
+        request.order_by.sort
+        == TraceItemAttributeValuesRequest.OrderBy.SORT_SEMVER
+    )
+    # the field round-trips through serialization
+    roundtripped = TraceItemAttributeValuesRequest()
+    roundtripped.ParseFromString(request.SerializeToString())
+    assert (
+        roundtripped.order_by.sort
+        == TraceItemAttributeValuesRequest.OrderBy.SORT_SEMVER
+    )
+
+
 def test_example_time_series_cross_item_query() -> None:
     """
     Find the number of spans with http.client over time in traces containing a span with op = 'db' that also contain errors with message = 'timeout'

--- a/rust/src/sentry_protos.snuba.v1.rs
+++ b/rust/src/sentry_protos.snuba.v1.rs
@@ -1651,6 +1651,10 @@ pub mod get_traces_request {
             /// Natural ordering: embedded runs of digits are compared by their
             /// numeric value, so e.g. "item2" sorts before "item10".
             Natural = 2,
+            /// Semantic-version ordering: values are parsed as semantic versions
+            /// (<https://semver.org>) and compared component by component, so e.g.
+            /// "1.9.0" sorts before "1.10.0".
+            Semver = 3,
         }
         impl Sort {
             /// String value of the enum field names used in the ProtoBuf definition.
@@ -1662,6 +1666,7 @@ pub mod get_traces_request {
                     Self::Unspecified => "SORT_UNSPECIFIED",
                     Self::Default => "SORT_DEFAULT",
                     Self::Natural => "SORT_NATURAL",
+                    Self::Semver => "SORT_SEMVER",
                 }
             }
             /// Creates an enum from field names used in the ProtoBuf definition.
@@ -1670,6 +1675,7 @@ pub mod get_traces_request {
                     "SORT_UNSPECIFIED" => Some(Self::Unspecified),
                     "SORT_DEFAULT" => Some(Self::Default),
                     "SORT_NATURAL" => Some(Self::Natural),
+                    "SORT_SEMVER" => Some(Self::Semver),
                     _ => None,
                 }
             }
@@ -1850,6 +1856,10 @@ pub mod trace_item_attribute_names_request {
             /// Natural ordering: embedded runs of digits are compared by their
             /// numeric value, so e.g. "item2" sorts before "item10".
             Natural = 2,
+            /// Semantic-version ordering: values are parsed as semantic versions
+            /// (<https://semver.org>) and compared component by component, so e.g.
+            /// "1.9.0" sorts before "1.10.0".
+            Semver = 3,
         }
         impl Sort {
             /// String value of the enum field names used in the ProtoBuf definition.
@@ -1861,6 +1871,7 @@ pub mod trace_item_attribute_names_request {
                     Self::Unspecified => "SORT_UNSPECIFIED",
                     Self::Default => "SORT_DEFAULT",
                     Self::Natural => "SORT_NATURAL",
+                    Self::Semver => "SORT_SEMVER",
                 }
             }
             /// Creates an enum from field names used in the ProtoBuf definition.
@@ -1869,6 +1880,7 @@ pub mod trace_item_attribute_names_request {
                     "SORT_UNSPECIFIED" => Some(Self::Unspecified),
                     "SORT_DEFAULT" => Some(Self::Default),
                     "SORT_NATURAL" => Some(Self::Natural),
+                    "SORT_SEMVER" => Some(Self::Semver),
                     _ => None,
                 }
             }
@@ -2084,6 +2096,10 @@ pub mod trace_item_attribute_values_request {
             /// Natural ordering: embedded runs of digits are compared by their
             /// numeric value, so e.g. "item2" sorts before "item10".
             Natural = 2,
+            /// Semantic-version ordering: values are parsed as semantic versions
+            /// (<https://semver.org>) and compared component by component, so e.g.
+            /// "1.9.0" sorts before "1.10.0".
+            Semver = 3,
         }
         impl Sort {
             /// String value of the enum field names used in the ProtoBuf definition.
@@ -2095,6 +2111,7 @@ pub mod trace_item_attribute_values_request {
                     Self::Unspecified => "SORT_UNSPECIFIED",
                     Self::Default => "SORT_DEFAULT",
                     Self::Natural => "SORT_NATURAL",
+                    Self::Semver => "SORT_SEMVER",
                 }
             }
             /// Creates an enum from field names used in the ProtoBuf definition.
@@ -2103,6 +2120,7 @@ pub mod trace_item_attribute_values_request {
                     "SORT_UNSPECIFIED" => Some(Self::Unspecified),
                     "SORT_DEFAULT" => Some(Self::Default),
                     "SORT_NATURAL" => Some(Self::Natural),
+                    "SORT_SEMVER" => Some(Self::Semver),
                     _ => None,
                 }
             }
@@ -2391,6 +2409,10 @@ pub mod trace_item_table_request {
             /// Natural ordering: embedded runs of digits are compared by their
             /// numeric value, so e.g. "item2" sorts before "item10".
             Natural = 2,
+            /// Semantic-version ordering: values are parsed as semantic versions
+            /// (<https://semver.org>) and compared component by component, so e.g.
+            /// "1.9.0" sorts before "1.10.0".
+            Semver = 3,
         }
         impl Sort {
             /// String value of the enum field names used in the ProtoBuf definition.
@@ -2402,6 +2424,7 @@ pub mod trace_item_table_request {
                     Self::Unspecified => "SORT_UNSPECIFIED",
                     Self::Default => "SORT_DEFAULT",
                     Self::Natural => "SORT_NATURAL",
+                    Self::Semver => "SORT_SEMVER",
                 }
             }
             /// Creates an enum from field names used in the ProtoBuf definition.
@@ -2410,6 +2433,7 @@ pub mod trace_item_table_request {
                     "SORT_UNSPECIFIED" => Some(Self::Unspecified),
                     "SORT_DEFAULT" => Some(Self::Default),
                     "SORT_NATURAL" => Some(Self::Natural),
+                    "SORT_SEMVER" => Some(Self::Semver),
                     _ => None,
                 }
             }


### PR DESCRIPTION
## Summary

Adds a `SORT_SEMVER` option to the `Sort` enum used by the EAP `OrderBy` messages, mirroring the existing `SORT_DEFAULT` (lexicographic) and `SORT_NATURAL` orderings introduced in #334 / #346.

Callers can now opt into semantic-version ordering when ordering by a textual column/attribute, so version-like values are compared component by component per [semver.org](https://semver.org) — e.g. `"1.9.0"` sorts before `"1.10.0"` rather than after it as lexicographic ordering would place it.

The new value is `SORT_SEMVER = 3`, so leaving `sort` unset (or using `SORT_DEFAULT`) preserves the historical behaviour and the change is backwards compatible.

## Changes

- `endpoint_trace_item_table.proto` — `TraceItemTableRequest.OrderBy.Sort`
- `endpoint_get_traces.proto` — `GetTracesRequest.OrderBy.Sort`
- `endpoint_trace_item_attributes.proto` — the attribute names and attribute values `OrderBy.Sort` enums
- Regenerated Rust bindings (`rust/src/sentry_protos.snuba.v1.rs`); `Cargo.lock` version synced to the current `0.46.0`
- Added Python round-trip tests covering `SORT_SEMVER` for the attribute names/values requests

## Testing

- `cargo build -p sentry_protos` (compiles cleanly)
- `pytest py/tests/test_snuba_v1.py -k sort` (4 passed)

https://claude.ai/code/session_01BuhNGCfhUp43ToijbyzwAz

---
_Generated by [Claude Code](https://claude.ai/code/session_01BuhNGCfhUp43ToijbyzwAz)_