### PR TITLE
ref: Add line item types for invoice analytics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/common/v1/line_item_details.proto
+++ b/proto/sentry_protos/billing/v1/common/v1/line_item_details.proto
@@ -5,6 +5,16 @@ package sentry_protos.billing.v1.common.v1;
 import "sentry_protos/billing/v1/common/v1/billable_metric.proto";
 import "sentry_protos/billing/v1/common/v1/unit_info.proto";
 
+// The invoice line item type strings used when charging for a line item,
+// distinguished by how the charge was incurred.
+message InvoiceMetadataTags {
+  // Type string for a reserved charge.
+  string reserved = 1;
+
+  // Type string for an pay-as-you-go charge.
+  string ondemand = 2;
+}
+
 // Details of a SKU line item in the billing system.
 message LineItemDetails {
   // Unique identifier for the line item.
@@ -29,4 +39,7 @@ message LineItemDetails {
   // New line items must be addable, and new consumers written, without anyone
   // hardcoding or reading a category off the line item.
   int32 line_item_category = 7 [deprecated = true];
+
+  // The invoice line item type strings for this line item.
+  InvoiceMetadataTags invoice_data = 8;
 }

--- a/rust/src/sentry_protos.billing.v1.common.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.common.v1.rs
@@ -218,6 +218,17 @@ impl BaseUnit {
         }
     }
 }
+/// The invoice line item type strings used when charging for a line item,
+/// distinguished by how the charge was incurred.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct InvoiceMetadataTags {
+    /// Type string for a reserved charge.
+    #[prost(string, tag = "1")]
+    pub reserved: ::prost::alloc::string::String,
+    /// Type string for an pay-as-you-go charge.
+    #[prost(string, tag = "2")]
+    pub ondemand: ::prost::alloc::string::String,
+}
 /// Details of a SKU line item in the billing system.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LineItemDetails {
@@ -245,6 +256,9 @@ pub struct LineItemDetails {
     #[deprecated]
     #[prost(int32, tag = "7")]
     pub line_item_category: i32,
+    /// The invoice line item type strings for this line item.
+    #[prost(message, optional, tag = "8")]
+    pub invoice_data: ::core::option::Option<InvoiceMetadataTags>,
 }
 /// Stripe-specific payment information for an organization.
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]


### PR DESCRIPTION
The item_type string is required used in the line items table by downstream analytics pipelines. We can serve it from platform data so that launching a new SKU only requires changes in the package service.