### PR TITLE
ref(snuba): HAS_ANY/HAS_ALL for array attribute key type comparisons

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/snuba/v1/trace_item_filter.proto
+++ b/proto/sentry_protos/snuba/v1/trace_item_filter.proto
@@ -29,6 +29,8 @@ message ComparisonFilter {
     OP_NOT_LIKE = 8; //string only
     OP_IN = 9; // array only
     OP_NOT_IN = 10; // array only
+    OP_HAS_ANY = 11; // array attribute_key type only
+    OP_HAS_ALL = 12; // array attribute_key type only
   }
   AttributeKey key = 1;
   Op op = 2;

--- a/rust/src/sentry_protos.snuba.v1.rs
+++ b/rust/src/sentry_protos.snuba.v1.rs
@@ -474,6 +474,10 @@ pub mod comparison_filter {
         In = 9,
         /// array only
         NotIn = 10,
+        /// array attribute_key type only
+        HasAny = 11,
+        /// array attribute_key type only
+        HasAll = 12,
     }
     impl Op {
         /// String value of the enum field names used in the ProtoBuf definition.
@@ -493,6 +497,8 @@ pub mod comparison_filter {
                 Self::NotLike => "OP_NOT_LIKE",
                 Self::In => "OP_IN",
                 Self::NotIn => "OP_NOT_IN",
+                Self::HasAny => "OP_HAS_ANY",
+                Self::HasAll => "OP_HAS_ALL",
             }
         }
         /// Creates an enum from field names used in the ProtoBuf definition.
@@ -509,6 +515,8 @@ pub mod comparison_filter {
                 "OP_NOT_LIKE" => Some(Self::NotLike),
                 "OP_IN" => Some(Self::In),
                 "OP_NOT_IN" => Some(Self::NotIn),
+                "OP_HAS_ANY" => Some(Self::HasAny),
+                "OP_HAS_ALL" => Some(Self::HasAll),
                 _ => None,
             }
         }


### PR DESCRIPTION
 We want array-set predicates against the typed attributes_array_* map columns:

 - `OP_HAS_ANY` → `hasAny(arrayElement(attributes_array_string, 'my_tags'), ['a','b'])` — any matches in the array attribute value
 - `OP_HAS_ALL` → `hasAll(arrayElement(attributes_array_string, 'my_tags'), ['a','b'])` — all matches are found in the array attribute value
 
Follow up in snuba would be to allow `OP_EQUALS` for arrays, since right now  OP_EQUALS on an array key means "any element equals this scalar", which essentially doing a hasAny with a singular value
 - `OP_EQUALS` with an array value → exact ordered array equality: `arrayElement(attributes_array_string, 'my_tags') = ['a','b']`