### PR TITLE
ref(billing-platform): Add package_uid to Trial proto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.49.1"
+version = "0.50.0"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/services/engagement/v1/endpoint_get_active_trials.proto
+++ b/proto/sentry_protos/billing/v1/services/engagement/v1/endpoint_get_active_trials.proto
@@ -18,6 +18,7 @@ message Trial {
   repeated TrialConfig config = 1;
   sentry_protos.billing.v1.Date start_date = 2;
   sentry_protos.billing.v1.Date end_date = 3;
+  optional string package_uid = 4;
 }
 
 message GetActiveTrialsRequest {

--- a/rust/src/sentry_protos.billing.v1.services.engagement.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.engagement.v1.rs
@@ -409,6 +409,8 @@ pub struct Trial {
     pub start_date: ::core::option::Option<super::super::super::Date>,
     #[prost(message, optional, tag = "3")]
     pub end_date: ::core::option::Option<super::super::super::Date>,
+    #[prost(string, optional, tag = "4")]
+    pub package_uid: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct GetActiveTrialsRequest {


### PR DESCRIPTION
Will be used by customer serializer to determine if a subscription trial is currently active