### PR TITLE
feat(billing-platform): Add override_package_uid to usage pricer GetPriceForContractRequest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.50.3"
+version = "0.51.0"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/services/rate_card/v1/endpoint_get_rate_card.proto
+++ b/proto/sentry_protos/billing/v1/services/rate_card/v1/endpoint_get_rate_card.proto
@@ -6,6 +6,13 @@ import "sentry_protos/billing/v1/services/rate_card/v1/rate_card.proto";
 
 message GetRateCardRequest {
   uint64 contract_id = 1;
+  // Price the contract under this package instead of its own, keeping the
+  // contract's overrides (e.g. reserved volumes, which stay fixed across a
+  // package change). Unset means use the contract's current package.
+  optional string override_package_uid = 2;
+  // Price the contract at this billing interval instead of its own. Unset means
+  // use the contract's current interval.
+  optional uint32 override_month_interval = 3;
 }
 
 message GetRateCardResponse {

--- a/proto/sentry_protos/billing/v1/services/usage_pricer/v1/endpoint_usage_pricer.proto
+++ b/proto/sentry_protos/billing/v1/services/usage_pricer/v1/endpoint_usage_pricer.proto
@@ -18,6 +18,14 @@ message GetPriceForContractRequest {
   // Instead of getting the usage for the contract at query time, pass in
   // pre-constructed usage data to simulate what the priced usage would be
   optional sentry_protos.billing.v1.services.usage.v1.GetUsageResponse simulated_usage = 3;
+  // When set, price the contract's usage against this package's rate card instead
+  // of the contract's own -- "what would this usage cost under package X". Used by
+  // checkout to freeze a PAYG cap against usage re-priced under an upgrade's target
+  // package. The contract's overrides (e.g. reserved volumes) still apply.
+  optional string override_package_uid = 4;
+  // Paired with override_package_uid: price at this billing interval instead of the
+  // contract's own, for an upgrade that also changes the interval.
+  optional uint32 override_month_interval = 5;
 }
 
 message SKUUsageSummary {

--- a/rust/src/sentry_protos.billing.v1.services.rate_card.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.rate_card.v1.rs
@@ -68,10 +68,19 @@ pub struct RateCard {
     #[prost(message, repeated, tag = "2")]
     pub shared_line_items: ::prost::alloc::vec::Vec<SharedRateCardLineItem>,
 }
-#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct GetRateCardRequest {
     #[prost(uint64, tag = "1")]
     pub contract_id: u64,
+    /// Price the contract under this package instead of its own, keeping the
+    /// contract's overrides (e.g. reserved volumes, which stay fixed across a
+    /// package change). Unset means use the contract's current package.
+    #[prost(string, optional, tag = "2")]
+    pub override_package_uid: ::core::option::Option<::prost::alloc::string::String>,
+    /// Price the contract at this billing interval instead of its own. Unset means
+    /// use the contract's current interval.
+    #[prost(uint32, optional, tag = "3")]
+    pub override_month_interval: ::core::option::Option<u32>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetRateCardResponse {

--- a/rust/src/sentry_protos.billing.v1.services.usage_pricer.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.usage_pricer.v1.rs
@@ -72,6 +72,16 @@ pub struct GetPriceForContractRequest {
     pub simulated_usage: ::core::option::Option<
         super::super::usage::v1::GetUsageResponse,
     >,
+    /// When set, price the contract's usage against this package's rate card instead
+    /// of the contract's own -- "what would this usage cost under package X". Used by
+    /// checkout to freeze a PAYG cap against usage re-priced under an upgrade's target
+    /// package. The contract's overrides (e.g. reserved volumes) still apply.
+    #[prost(string, optional, tag = "4")]
+    pub override_package_uid: ::core::option::Option<::prost::alloc::string::String>,
+    /// Paired with override_package_uid: price at this billing interval instead of the
+    /// contract's own, for an upgrade that also changes the interval.
+    #[prost(uint32, optional, tag = "5")]
+    pub override_month_interval: ::core::option::Option<u32>,
 }
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct SkuUsageSummary {


### PR DESCRIPTION
Changes to support https://github.com/getsentry/getsentry/pull/21200