### PR TITLE
chore(billing-platform): Add can_product_trial to line items

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/services/package/v1/package.proto
+++ b/proto/sentry_protos/billing/v1/services/package/v1/package.proto
@@ -34,6 +34,9 @@ message LineItemConfig {
     bool is_unlimited_trial = 10;
     uint64 num_trial_units = 11;
   }
+
+  // Whether this LineItem is eligible for a product trial.
+  bool can_product_trial = 12;
 }
 
 // Represents a budget included in a package that is collectively used by one or more line items,
@@ -66,6 +69,9 @@ message SharedLineItemPool {
     bool is_unlimited_trial = 9;
     uint64 num_trial_units = 10;
   }
+
+  // Whether this LineItem is eligible for a product trial.
+  bool can_product_trial = 11;
 }
 
 message PackageConfig {

--- a/rust/src/sentry_protos.billing.v1.services.package.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.package.v1.rs
@@ -26,6 +26,9 @@ pub struct LineItemConfig {
     pub uncapped_rate: ::core::option::Option<
         super::super::super::common::v1::TieredPricingRate,
     >,
+    /// Whether this LineItem is eligible for a product trial.
+    #[prost(bool, tag = "12")]
+    pub can_product_trial: bool,
     /// how many of this lineitem are included in the package, the customer can reserve more on their contract
     #[prost(oneof = "line_item_config::IncludedReservedUnits", tags = "5, 6")]
     pub included_reserved_units: ::core::option::Option<
@@ -99,6 +102,9 @@ pub struct SharedLineItemPool {
     pub reserved_tier: ::core::option::Option<
         super::super::super::common::v1::TieredPricingRate,
     >,
+    /// Whether this LineItem is eligible for a product trial.
+    #[prost(bool, tag = "11")]
+    pub can_product_trial: bool,
     /// How many units are available for a PackageConfig during a subscription trial? For packages that are not eligible for trials,
     /// this field will be unset for all line items.
     #[prost(oneof = "shared_line_item_pool::TrialUnits", tags = "9, 10")]


### PR DESCRIPTION
will be used to address [this TODO](https://github.com/getsentry/getsentry/blob/1f4e3a405dbe04cf155a119043b84aaed81f9da2/getsentry/billing/platform/services/engagement/service.py#L537-L538)