### PR TITLE
feat(taskbroker): Mark Callback URL Field as Deprecated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.50.3"
+version = "0.51.0"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/taskbroker/v1/taskbroker.proto
+++ b/proto/sentry_protos/taskbroker/v1/taskbroker.proto
@@ -160,6 +160,8 @@ service WorkerService {
 
 message PushTaskRequest {
   TaskActivation task = 1;
+
+  string callback_url = 2 [deprecated = true];
 }
 
 message PushTaskResponse {}

--- a/proto/sentry_protos/taskbroker/v1/taskbroker.proto
+++ b/proto/sentry_protos/taskbroker/v1/taskbroker.proto
@@ -159,6 +159,9 @@ service WorkerService {
 }
 
 message PushTaskRequest {
+  reserved 2;
+  reserved "callback_url";
+
   TaskActivation task = 1;
 }
 

--- a/proto/sentry_protos/taskbroker/v1/taskbroker.proto
+++ b/proto/sentry_protos/taskbroker/v1/taskbroker.proto
@@ -160,8 +160,6 @@ service WorkerService {
 
 message PushTaskRequest {
   TaskActivation task = 1;
-
-  string callback_url = 2;
 }
 
 message PushTaskResponse {}

--- a/proto/sentry_protos/taskbroker/v1/taskbroker.proto
+++ b/proto/sentry_protos/taskbroker/v1/taskbroker.proto
@@ -159,9 +159,6 @@ service WorkerService {
 }
 
 message PushTaskRequest {
-  reserved 2;
-  reserved "callback_url";
-
   TaskActivation task = 1;
 }
 

--- a/rust/src/sentry_protos.taskbroker.v1.rs
+++ b/rust/src/sentry_protos.taskbroker.v1.rs
@@ -137,6 +137,9 @@ pub struct SetBatchActivationStatusResponse {}
 pub struct PushTaskRequest {
     #[prost(message, optional, tag = "1")]
     pub task: ::core::option::Option<TaskActivation>,
+    #[deprecated]
+    #[prost(string, tag = "2")]
+    pub callback_url: ::prost::alloc::string::String,
 }
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct PushTaskResponse {}

--- a/rust/src/sentry_protos.taskbroker.v1.rs
+++ b/rust/src/sentry_protos.taskbroker.v1.rs
@@ -137,8 +137,6 @@ pub struct SetBatchActivationStatusResponse {}
 pub struct PushTaskRequest {
     #[prost(message, optional, tag = "1")]
     pub task: ::core::option::Option<TaskActivation>,
-    #[prost(string, tag = "2")]
-    pub callback_url: ::prost::alloc::string::String,
 }
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct PushTaskResponse {}


### PR DESCRIPTION
## Linear
Refs [STREAM-1663](https://linear.app/getsentry/issue/STREAM-1663/remove-callback-url-field-from-pushtaskrequest)

## Description
The `PushTaskRequest` message has a `callback_url` field. It is no longer used by taskworkers, and the taskbroker sets it to an empty string. Let's mark it as deprecated.