### PR TITLE
feat(snuba): Add last_seen to EAP attribute names, readable and sortable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.53.0"
+version = "0.53.1"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/snuba/v1/endpoint_trace_item_attributes.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_trace_item_attributes.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package sentry_protos.snuba.v1;
 
+import "google/protobuf/timestamp.proto";
 import "sentry_protos/snuba/v1/request_common.proto";
 import "sentry_protos/snuba/v1/trace_item_attribute.proto";
 import "sentry_protos/snuba/v1/trace_item_filter.proto";
@@ -121,6 +122,12 @@ message TraceItemAttributeNamesResponse {
     // (order_by.column = COLUMN_COUNT); unset otherwise. The presence of this
     // field distinguishes "not computed" from a genuine count of zero.
     optional uint64 count = 3;
+
+    // optional, the most recent time this attribute was seen across the
+    // matched trace items, within the request's time range. Unset when the
+    // endpoint does not compute it, which distinguishes "not computed" from a
+    // genuine timestamp.
+    google.protobuf.Timestamp last_seen = 4;
   }
   // all attributes that matched the filters in the request
   repeated Attribute attributes = 1;

--- a/proto/sentry_protos/snuba/v1/endpoint_trace_item_attributes.proto
+++ b/proto/sentry_protos/snuba/v1/endpoint_trace_item_attributes.proto
@@ -30,11 +30,15 @@ message TraceItemAttributeNamesRequest {
       // Order by how frequently the attribute occurs across the matched trace
       // items (its count).
       COLUMN_COUNT = 2;
+      // Order by when the attribute was most recently seen across the matched
+      // trace items (its last_seen timestamp). Combine with
+      // `descending = true` for most-recently-used first.
+      COLUMN_LAST_SEEN = 3;
     }
 
     // Sort selects which sort order is applied when ordering by a textual
-    // column (i.e. COLUMN_NAME). It has no effect when ordering by a numeric
-    // column such as COLUMN_COUNT.
+    // column (i.e. COLUMN_NAME). It has no effect when ordering by a
+    // non-textual column such as COLUMN_COUNT or COLUMN_LAST_SEEN.
     enum Sort {
       // Defaults to SORT_DEFAULT (lexicographic). This keeps the behaviour
       // backwards compatible when `sort` is left unset.
@@ -62,7 +66,8 @@ message TraceItemAttributeNamesRequest {
     // The sort order to apply when ordering by a textual column (COLUMN_NAME).
     // Defaults to SORT_DEFAULT (lexicographic) when unset, preserving the
     // historical behaviour. Set to SORT_NATURAL to order alphanumeric names
-    // naturally (e.g. "item2" before "item10"). Ignored for COLUMN_COUNT.
+    // naturally (e.g. "item2" before "item10"). Ignored for COLUMN_COUNT and
+    // COLUMN_LAST_SEEN.
     Sort sort = 3;
   }
 
@@ -124,9 +129,15 @@ message TraceItemAttributeNamesResponse {
     optional uint64 count = 3;
 
     // optional, the most recent time this attribute was seen across the
-    // matched trace items, within the request's time range. Unset when the
-    // endpoint does not compute it, which distinguishes "not computed" from a
-    // genuine timestamp.
+    // matched trace items, within the request's time range. Only populated
+    // when the request opts into an ordering that aggregates the attributes
+    // (order_by.column = COLUMN_COUNT or COLUMN_LAST_SEEN); unset otherwise.
+    // Being unset therefore means "not computed" rather than "never seen".
+    //
+    // This is a best-effort, approximate value: it is derived from a periodic
+    // roll-up rather than the trace items themselves, so it can lag by a
+    // small number of seconds. Use it for recency ranking, not as an exact
+    // event timestamp.
     google.protobuf.Timestamp last_seen = 4;
   }
   // all attributes that matched the filters in the request

--- a/rust/src/sentry_protos.snuba.v1.rs
+++ b/rust/src/sentry_protos.snuba.v1.rs
@@ -1967,6 +1967,12 @@ pub mod trace_item_attribute_names_response {
         /// field distinguishes "not computed" from a genuine count of zero.
         #[prost(uint64, optional, tag = "3")]
         pub count: ::core::option::Option<u64>,
+        /// optional, the most recent time this attribute was seen across the
+        /// matched trace items, within the request's time range. Unset when the
+        /// endpoint does not compute it, which distinguishes "not computed" from a
+        /// genuine timestamp.
+        #[prost(message, optional, tag = "4")]
+        pub last_seen: ::core::option::Option<::prost_types::Timestamp>,
     }
 }
 /// TraceItemAttributeValuesRequest is a request to the TraceItemAttributeValues endpoint,

--- a/rust/src/sentry_protos.snuba.v1.rs
+++ b/rust/src/sentry_protos.snuba.v1.rs
@@ -1788,7 +1788,8 @@ pub mod trace_item_attribute_names_request {
         /// The sort order to apply when ordering by a textual column (COLUMN_NAME).
         /// Defaults to SORT_DEFAULT (lexicographic) when unset, preserving the
         /// historical behaviour. Set to SORT_NATURAL to order alphanumeric names
-        /// naturally (e.g. "item2" before "item10"). Ignored for COLUMN_COUNT.
+        /// naturally (e.g. "item2" before "item10"). Ignored for COLUMN_COUNT and
+        /// COLUMN_LAST_SEEN.
         #[prost(enumeration = "order_by::Sort", tag = "3")]
         pub sort: i32,
     }
@@ -1816,6 +1817,10 @@ pub mod trace_item_attribute_names_request {
             /// Order by how frequently the attribute occurs across the matched trace
             /// items (its count).
             Count = 2,
+            /// Order by when the attribute was most recently seen across the matched
+            /// trace items (its last_seen timestamp). Combine with
+            /// `descending = true` for most-recently-used first.
+            LastSeen = 3,
         }
         impl Column {
             /// String value of the enum field names used in the ProtoBuf definition.
@@ -1827,6 +1832,7 @@ pub mod trace_item_attribute_names_request {
                     Self::Unspecified => "COLUMN_UNSPECIFIED",
                     Self::Name => "COLUMN_NAME",
                     Self::Count => "COLUMN_COUNT",
+                    Self::LastSeen => "COLUMN_LAST_SEEN",
                 }
             }
             /// Creates an enum from field names used in the ProtoBuf definition.
@@ -1835,13 +1841,14 @@ pub mod trace_item_attribute_names_request {
                     "COLUMN_UNSPECIFIED" => Some(Self::Unspecified),
                     "COLUMN_NAME" => Some(Self::Name),
                     "COLUMN_COUNT" => Some(Self::Count),
+                    "COLUMN_LAST_SEEN" => Some(Self::LastSeen),
                     _ => None,
                 }
             }
         }
         /// Sort selects which sort order is applied when ordering by a textual
-        /// column (i.e. COLUMN_NAME). It has no effect when ordering by a numeric
-        /// column such as COLUMN_COUNT.
+        /// column (i.e. COLUMN_NAME). It has no effect when ordering by a
+        /// non-textual column such as COLUMN_COUNT or COLUMN_LAST_SEEN.
         #[derive(
             Clone,
             Copy,
@@ -1968,9 +1975,15 @@ pub mod trace_item_attribute_names_response {
         #[prost(uint64, optional, tag = "3")]
         pub count: ::core::option::Option<u64>,
         /// optional, the most recent time this attribute was seen across the
-        /// matched trace items, within the request's time range. Unset when the
-        /// endpoint does not compute it, which distinguishes "not computed" from a
-        /// genuine timestamp.
+        /// matched trace items, within the request's time range. Only populated
+        /// when the request opts into an ordering that aggregates the attributes
+        /// (order_by.column = COLUMN_COUNT or COLUMN_LAST_SEEN); unset otherwise.
+        /// Being unset therefore means "not computed" rather than "never seen".
+        ///
+        /// This is a best-effort, approximate value: it is derived from a periodic
+        /// roll-up rather than the trace items themselves, so it can lag by a
+        /// small number of seconds. Use it for recency ranking, not as an exact
+        /// event timestamp.
         #[prost(message, optional, tag = "4")]
         pub last_seen: ::core::option::Option<::prost_types::Timestamp>,
     }


### PR DESCRIPTION
Makes the `last_seen` timestamp from the v2 co-occurring attributes table available to `TraceItemAttributeNames`, both to read and to sort by.

- `TraceItemAttributeNamesResponse.Attribute.last_seen` (field `4`) — the most recent time the attribute was seen within the request's time range.
- `TraceItemAttributeNamesRequest.OrderBy.Column.COLUMN_LAST_SEEN` (value `3`) — order by recency; combine with `descending = true` for most-recently-used first.

getsentry/snuba#8239 switches the endpoint to the v2 co-occurring attributes table, a `SummingMergeTree` that already tracks when each attribute set was last seen. That makes both of these cheap: reading it is a column select, and ordering by it is `max(last_seen)` grouped by key — the same shape as the existing `sum(count)`. The point is to let the UI surface or demote stale attributes rather than showing every key that ever existed in the retention window.

Following the existing `count` field, `last_seen` is only populated for the orderings that aggregate the attributes, so unset means "not computed" rather than "never seen".

Two things I documented on the field, since they're easy to get wrong from the outside:

- **It is approximate.** The value comes from the table's periodic roll-up rather than the trace items themselves, so it can lag by a few seconds. It suits recency ranking, not exact event timestamps.
- **`Sort` does not apply to it.** `Sort` only affects textual columns (`COLUMN_NAME`); I updated its comments to say "non-textual" rather than enumerating `COLUMN_COUNT`, so it covers this and stays correct as columns are added.

### Verification

- `buf lint` clean; `buf format` made no changes.
- `buf breaking --against '.git#branch=main'` passes — both additions are backwards compatible.
- Generated the Python bindings and round-tripped a message through the wire: `last_seen` sets/reads correctly, `HasField` distinguishes set from unset, and `COLUMN_LAST_SEEN` is selectable on `OrderBy`.
- Parsed a new-format message (with `last_seen`) using the currently released 0.53.1 schema to confirm old clients tolerate the new field.
- Rust bindings regenerated with `make build-rust`.

Snuba-side implementation to follow once this is released.
