### PR TITLE
feat(billing-platform): Add Activation.Change enum to pricing config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.53.1"
+version = "0.54.0"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/services/contract/v1/pricing_config.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/pricing_config.proto
@@ -69,7 +69,15 @@ message LineItemUids {
 }
 
 // For activating add-ons that do not necessarily require Reservation or PAYGBudget changes
-message Activation {}
+message Activation {
+  // A checkout operation on the activation. The default adds the activation. A
+  // contract never stores CHANGE_REMOVE. It is a request to delete the activation.
+  enum Change {
+    CHANGE_UNSPECIFIED = 0;
+    CHANGE_REMOVE = 1;
+  }
+  Change change = 1;
+}
 
 message UserConfig {
   PAYGBudget payg_budget = 1;

--- a/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
@@ -388,7 +388,51 @@ pub struct LineItemUids {
 }
 /// For activating add-ons that do not necessarily require Reservation or PAYGBudget changes
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct Activation {}
+pub struct Activation {
+    #[prost(enumeration = "activation::Change", tag = "1")]
+    pub change: i32,
+}
+/// Nested message and enum types in `Activation`.
+pub mod activation {
+    /// A checkout operation on the activation. The default adds the activation. A
+    /// contract never stores CHANGE_REMOVE. It is a request to delete the activation.
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
+    #[repr(i32)]
+    pub enum Change {
+        Unspecified = 0,
+        Remove = 1,
+    }
+    impl Change {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                Self::Unspecified => "CHANGE_UNSPECIFIED",
+                Self::Remove => "CHANGE_REMOVE",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "CHANGE_UNSPECIFIED" => Some(Self::Unspecified),
+                "CHANGE_REMOVE" => Some(Self::Remove),
+                _ => None,
+            }
+        }
+    }
+}
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct UserConfig {
     #[prost(message, optional, tag = "1")]


### PR DESCRIPTION
## Summary

Add a `Change` enum to the `Activation` message in the contract pricing config.

The default value `CHANGE_UNSPECIFIED` adds the activation. This keeps the current behavior. The `CHANGE_REMOVE` value is a request to delete the activation.

Checkout needs a way to disable a seat-based add-on, for example Seer. A contract never stores `CHANGE_REMOVE`. The value only appears in a checkout request. The contract service deletes the activation link when it reads this value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)