### PR TITLE
chore(py): document strict editable installs for mypy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,12 @@ clean-py:
 	rm -rf ./py/sentry_protos
 	rm -rf ./py/sentry_protos.egg-info
 
+# Prefer this over bare `pip install -e ./py`. Lenient editable mode
+# (setuptools MetaPathFinder) breaks mypy package resolution.
+.PHONY: install-py-editable
+install-py-editable:
+	pip install -e ./py --config-settings editable_mode=strict
+
 # Rust client targets
 .PHONY: build-rust
 build-rust:
@@ -74,5 +80,5 @@ docs: ensure-protoc
 
 .PHONY: test-py
 test-py:
-	cd py && pip install -e .
+	cd py && pip install -e . --config-settings editable_mode=strict
 	pytest py/tests/

--- a/README.md
+++ b/README.md
@@ -50,11 +50,24 @@ From the root of `sentry-protos` run:
 make build-py
 ```
 
-Then in your application install the python bindings with pip.
+Then install the python bindings into your application venv. Prefer this
+from the **application** checkout (so direnv keeps that venv active):
 
 ```shell
-# CWD is in your python application
 pip install -e ../sentry-protos/py --config-settings editable_mode=strict
+```
+
+Always use `editable_mode=strict`. Bare `pip install -e` uses setuptools'
+lenient MetaPathFinder mode: Python imports still work, but **mypy** cannot
+resolve packages and reports mass `import-not-found` errors for
+`sentry_protos.*`. Fix by reinstalling with `strict`, or by installing a
+built wheel instead of an editable install.
+
+Optional helper from the sentry-protos root (only when `pip` is already the
+application env — this repo's direnv activates its own `.venv` on enter):
+
+```shell
+make install-py-editable
 ```
 
 As you make changes to proto files, you will need to regenerate bindings with `make build-py`.


### PR DESCRIPTION
## Summary
- Add `make install-py-editable` (`editable_mode=strict`) and use the same mode in `test-py`, so bare lenient `-e` is no longer the Makefile default.
- Update the README to prefer the **app-checkout** pip one-liner with `editable_mode=strict` (direnv-safe), document the mypy MetaPathFinder failure mode, and keep the make target as an optional helper with a direnv caveat.

Bare `pip install -e` still runs under Python but leaves mypy unable to resolve `sentry_protos.*`.

## Test plan
- [ ] From an app checkout with its venv active: `pip install -e ../sentry-protos/py --config-settings editable_mode=strict`, then confirm mypy resolves `sentry_protos` imports
- [ ] `make test-py` succeeds with the strict editable install
- [ ] Confirm bare `pip install -e ./py` still reproduces mypy `import-not-found` (optional regression check)


Made with [Cursor](https://cursor.com)