### PR TITLE
chore(billing-platform): Add start_new_term to from checkout service to rollover

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sentry_protos"
-version = "0.56.0"
+version = "0.57.1"
 dependencies = [
  "prost",
  "prost-types",

--- a/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_rollover_contract.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_rollover_contract.proto
@@ -26,12 +26,7 @@ message RolloverContractRequest {
   optional string tax_transaction_code = 7;
 
   // Roll the contract over as of now instead of at its period end: the current
-  // contract is closed immediately and the new contract starts now. Used for
-  // contract changes that take effect immediately (e.g. checkout upgrades).
-  // The request's pending_change is applied to the new contract regardless of
-  // whether the term was due to renew; a change that keeps the billing
-  // interval stays co-terminous with the current term, while an interval
-  // change (or an already-ended term) starts a fresh term now.
+  // contract is closed immediately and the new contract starts now.
   bool immediate = 8;
 
   // Whether the requested change should result in a new billing period.

--- a/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_rollover_contract.proto
+++ b/proto/sentry_protos/billing/v1/services/contract/v1/endpoint_rollover_contract.proto
@@ -33,6 +33,9 @@ message RolloverContractRequest {
   // interval stays co-terminous with the current term, while an interval
   // change (or an already-ended term) starts a fresh term now.
   bool immediate = 8;
+
+  // Whether the requested change should result in a new billing period.
+  bool start_new_term = 9;
 }
 
 message RolloverContractResponse {

--- a/proto/sentry_protos/billing/v1/services/invoicer/v1/endpoint_bill_contract_change.proto
+++ b/proto/sentry_protos/billing/v1/services/invoicer/v1/endpoint_bill_contract_change.proto
@@ -22,6 +22,9 @@ message BillContractChangeRequest {
   // consumes, but here it applies immediately rather than at a period boundary,
   // so the caller does not stage it in the pending-change store.
   sentry_protos.billing.v1.common.v1.PendingChange change = 3;
+
+  // Whether the requested change should result in a new billing period.
+  bool start_new_term = 4;
 }
 
 message BillContractChangeResponse {

--- a/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
@@ -1022,12 +1022,7 @@ pub struct RolloverContractRequest {
     #[prost(string, optional, tag = "7")]
     pub tax_transaction_code: ::core::option::Option<::prost::alloc::string::String>,
     /// Roll the contract over as of now instead of at its period end: the current
-    /// contract is closed immediately and the new contract starts now. Used for
-    /// contract changes that take effect immediately (e.g. checkout upgrades).
-    /// The request's pending_change is applied to the new contract regardless of
-    /// whether the term was due to renew; a change that keeps the billing
-    /// interval stays co-terminous with the current term, while an interval
-    /// change (or an already-ended term) starts a fresh term now.
+    /// contract is closed immediately and the new contract starts now.
     #[prost(bool, tag = "8")]
     pub immediate: bool,
     /// Whether the requested change should result in a new billing period.

--- a/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.contract.v1.rs
@@ -1030,6 +1030,9 @@ pub struct RolloverContractRequest {
     /// change (or an already-ended term) starts a fresh term now.
     #[prost(bool, tag = "8")]
     pub immediate: bool,
+    /// Whether the requested change should result in a new billing period.
+    #[prost(bool, tag = "9")]
+    pub start_new_term: bool,
 }
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct RolloverContractResponse {

--- a/rust/src/sentry_protos.billing.v1.services.invoicer.v1.rs
+++ b/rust/src/sentry_protos.billing.v1.services.invoicer.v1.rs
@@ -22,6 +22,9 @@ pub struct BillContractChangeRequest {
     /// so the caller does not stage it in the pending-change store.
     #[prost(message, optional, tag = "3")]
     pub change: ::core::option::Option<super::super::super::common::v1::PendingChange>,
+    /// Whether the requested change should result in a new billing period.
+    #[prost(bool, tag = "4")]
+    pub start_new_term: bool,
 }
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct BillContractChangeResponse {


### PR DESCRIPTION
Checkout service determines whether we should apply immediate changes to the current term or if we should start a new billing period.